### PR TITLE
PHP short tag fix

### DIFF
--- a/resources/views/feed.blade.php
+++ b/resources/views/feed.blade.php
@@ -1,5 +1,5 @@
 {{-- Using an echo tag here so the `<? ... ?>` won't get parsed as short tags  --}}
-<?= '<?xml version="1.0" encoding="UTF-8" ?>' ?>
+<?= '<?xml version="1.0" encoding="UTF-8" ?>'.PHP_EOL ?>
 <feed xmlns="http://www.w3.org/2005/Atom">
     @foreach($meta as $key => $metaItem)
         @if($key === 'link')

--- a/resources/views/feed.blade.php
+++ b/resources/views/feed.blade.php
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+{{-- Using an echo tag here so the `<? ... ?>` won't get parsed as short tags  --}}
+<?= '<?xml version="1.0" encoding="UTF-8" ?>' ?>
 <feed xmlns="http://www.w3.org/2005/Atom">
     @foreach($meta as $key => $metaItem)
         @if($key === 'link')


### PR DESCRIPTION
Use an echo tag instead so the `<? ... ?>` from the xml declaration won't get parsed as a set of short tags.