### PR TITLE
Allow html tags in summary section.

### DIFF
--- a/resources/views/feed.blade.php
+++ b/resources/views/feed.blade.php
@@ -19,7 +19,7 @@
                 <name> <![CDATA[{{ $item->getFeedItemAuthor() }}]]></name>
             </author>
             <summary type="html">
-                <![CDATA[{{ $item->getFeedItemSummary() }}]]>
+                <![CDATA[{!! $item->getFeedItemSummary() !!}]]>
             </summary>
             <updated>{{ $item->getFeedItemUpdated()->toAtomString() }}</updated>
         </entry>


### PR DESCRIPTION
Currently, this package uses Blade double curly braces ({{ }}) in the summary section.  This escapes any html and makes the 'type="html"' declaration pointless.