### PR TITLE
Pass parameter to get feed items()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to `laravel-feed` will be documented in this file
 
+## 1.4.0 - 2017-05-10
+- allow a filter to be passed with items in config
+
 ## 1.3.0 - 2017-04-13
 - allow views to be published
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ return [
             /*
              * Here you can specify which class and method will return
              * the items that should appear in the feed. For example:
-             * '\App\Model@getAllFeedItems'
+             * '\App\Model@getAllFeedItems' or ['\App\Model@getAllFeedItems', 'filter']
              */
             'items' => '',
 

--- a/src/Feed.php
+++ b/src/Feed.php
@@ -14,8 +14,8 @@ class Feed
     public function __construct(array $feedConfiguration)
     {
         $this->feedConfiguration = $feedConfiguration;
-        if (! str_contains($feedConfiguration['items'], '@')) {
-            throw InvalidConfiguration::delimiterNotPresent($feedConfiguration['items']);
+        if (! str_contains($this->getFeedConfigurationItems(), '@')) {
+            throw InvalidConfiguration::delimiterNotPresent($this->getFeedConfigurationItems());
         }
     }
 
@@ -26,13 +26,31 @@ class Feed
 
     public function getFeedContent()
     {
-        list($class, $method) = explode('@', $this->feedConfiguration['items']);
+        list($class, $method) = explode('@', $this->getFeedConfigurationItems());
 
-        $items = app($class)->{$method}();
+        $items = app($class)->{$method}($this->getFeedConfigurationItemsFilter());
 
         $meta = ['id' => url($this->feedConfiguration['url']), 'link' => url($this->feedConfiguration['url']), 'title' => $this->feedConfiguration['title'], 'updated' => $this->getLastUpdatedDate($items)];
 
         return view('laravel-feed::feed', compact('meta', 'items'))->render();
+    }
+
+    protected function getFeedConfigurationItems()
+    {
+        if (is_array($this->feedConfiguration['items'])) {
+            return $this->feedConfiguration['items'][0];
+        }
+
+        return $this->feedConfiguration['items'];
+    }
+
+    protected function getFeedConfigurationItemsFilter()
+    {
+        if (is_array($this->feedConfiguration['items'])) {
+            return $this->feedConfiguration['items'][1];
+        }
+
+        return null;
     }
 
     protected function getLastUpdatedDate(Collection $items)

--- a/src/Feed.php
+++ b/src/Feed.php
@@ -14,8 +14,8 @@ class Feed
     public function __construct(array $feedConfiguration)
     {
         $this->feedConfiguration = $feedConfiguration;
-        if (! str_contains($this->getFeedConfigurationItems(), '@')) {
-            throw InvalidConfiguration::delimiterNotPresent($this->getFeedConfigurationItems());
+        if (! str_contains($this->getFeedMethod(), '@')) {
+            throw InvalidConfiguration::delimiterNotPresent($this->getFeedMethod());
         }
     }
 
@@ -26,31 +26,23 @@ class Feed
 
     public function getFeedContent()
     {
-        list($class, $method) = explode('@', $this->getFeedConfigurationItems());
+        list($class, $method) = explode('@', $this->getFeedMethod());
 
-        $items = app($class)->{$method}($this->getFeedConfigurationItemsFilter());
+        $items = app($class)->{$method}($this->getFeedArguments());
 
         $meta = ['id' => url($this->feedConfiguration['url']), 'link' => url($this->feedConfiguration['url']), 'title' => $this->feedConfiguration['title'], 'updated' => $this->getLastUpdatedDate($items)];
 
         return view('laravel-feed::feed', compact('meta', 'items'))->render();
     }
 
-    protected function getFeedConfigurationItems()
+    protected function getFeedMethod()
     {
-        if (is_array($this->feedConfiguration['items'])) {
-            return $this->feedConfiguration['items'][0];
-        }
-
-        return $this->feedConfiguration['items'];
+        return is_array($this->feedConfiguration['items']) ? $this->feedConfiguration['items'][0] : $this->feedConfiguration['items'];
     }
 
-    protected function getFeedConfigurationItemsFilter()
+    protected function getFeedArguments()
     {
-        if (is_array($this->feedConfiguration['items'])) {
-            return $this->feedConfiguration['items'][1];
-        }
-
-        return null;
+        return is_array($this->feedConfiguration['items']) ? $this->feedConfiguration['items'][1] : null;
     }
 
     protected function getLastUpdatedDate(Collection $items)

--- a/tests/DummyRepository.php
+++ b/tests/DummyRepository.php
@@ -15,7 +15,7 @@ class DummyRepository
         ]);
     }
 
-    public function getAllWithFilter($filter = '')
+    public function getAllWithArguments($filter = '')
     {
         if ($filter != '') {
             return collect([

--- a/tests/DummyRepository.php
+++ b/tests/DummyRepository.php
@@ -14,4 +14,21 @@ class DummyRepository
             new DummyItem(),
         ]);
     }
+
+    public function getAllWithFilter($filter = '')
+    {
+        if ($filter != '') {
+            return collect([
+                new DummyItem(),
+            ]);
+        }
+
+        return collect([
+            new DummyItem(),
+            new DummyItem(),
+            new DummyItem(),
+            new DummyItem(),
+            new DummyItem(),
+        ]);
+    }
 }

--- a/tests/FeedTest.php
+++ b/tests/FeedTest.php
@@ -7,7 +7,7 @@ use Spatie\Feed\Exceptions\InvalidConfiguration;
 
 class FeedTest extends TestCase
 {
-    protected $feedNames = ['feed1', 'feed2'];
+    protected $feedNames = ['feed1', 'feed2', 'feed3'];
 
     /** @test */
     public function all_feeds_are_available_on_their_registered_routes()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -40,7 +40,7 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
                 'description' => 'This is feed 2 from the unit tests',
             ],
             [
-                'items'       => ['Spatie\Feed\Test\DummyRepository@getAllWithFilter', 'filter'],
+                'items'       => ['Spatie\Feed\Test\DummyRepository@getAllWithArguments', 'filter'],
                 'url'         => '/feed3',
                 'title'       => 'Feed 3',
                 'description' => 'This is feed 3 from the unit tests',

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -39,6 +39,12 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
                 'title'       => 'Feed 2',
                 'description' => 'This is feed 2 from the unit tests',
             ],
+            [
+                'items'       => ['Spatie\Feed\Test\DummyRepository@getAllWithFilter', 'filter'],
+                'url'         => '/feed3',
+                'title'       => 'Feed 3',
+                'description' => 'This is feed 3 from the unit tests',
+            ],
         ];
 
         $app['config']->set('laravel-feed.feeds', $feed);

--- a/tests/__snapshots__/FeedTest__all_feed_items_have_expected_data__3.xml
+++ b/tests/__snapshots__/FeedTest__all_feed_items_have_expected_data__3.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <id>http://localhost/feedBaseUrl/feed3</id>
+  <link href="http://localhost/feedBaseUrl/feed3"/>
+  <title><![CDATA[Feed 3]]></title>
+  <updated>2016-01-01T00:00:00+01:00</updated>
+  <entry>
+    <title><![CDATA[feedItemTitle]]></title>
+    <link rel="alternate" href="https://localhost/news/testItem1"/>
+    <id>http://localhost/1</id>
+    <author>
+      <name><![CDATA[feedItemAuthor]]></name>
+    </author>
+    <summary type="html"><![CDATA[feedItemSummary]]></summary>
+    <updated>2016-01-01T00:00:00+01:00</updated>
+  </entry>
+</feed>

--- a/tests/__snapshots__/FeedTest__it_can_render_all_feed_links_via_a_view__1.php
+++ b/tests/__snapshots__/FeedTest__it_can_render_all_feed_links_via_a_view__1.php
@@ -2,4 +2,5 @@
 
 return '<link rel="alternate" type="application/rss+xml" href="http://localhost/feedBaseUrl/feed1" title="Feed 1">
     <link rel="alternate" type="application/rss+xml" href="http://localhost/feedBaseUrl/feed2" title="Feed 2">
+    <link rel="alternate" type="application/rss+xml" href="http://localhost/feedBaseUrl/feed3" title="Feed 3">
 ';


### PR DESCRIPTION
Added ability to pass a filter with items in the config.

You can now do this
```php
return [
    'feeds' => [
        [
            'items' => ['App\NewsItem@getFeedItemsForCategory', 'news'],
            ...
```
As well as this:
```php
return [
    'feeds' => [
        [
            'items' => 'App\NewsItem@getFeedItemsForCategory',
            ...
```
