### PR TITLE
Fixed StyleCI config

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,8 +1,5 @@
 preset: laravel
 
-linting: true
-
 finder:
-  not-contains:
+  exclude:
     - "__snapshots__"
-    


### PR DESCRIPTION
The `not-contains` option will only match file names. `exclude` will match folders.

Also, the linting option is deprecated. Only true is allowed.