### PR TITLE
[LaraPackagePort] Analyse for Laravel 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,12 +25,12 @@
     ],
     "require": {
         "php": "^7.0",
-        "illuminate/support": "~5.1.0|~5.2.0|~5.3.0|~5.4.0|~5.5.x-dev",
+        "illuminate/support": "~5.1.0|~5.2.0|~5.3.0|~5.4.0|~5.5.x-dev|~5.5.x-dev",
         "nesbot/carbon": "^1.0",
         "spatie/phpunit-snapshot-assertions": "^0.4.1"
     },
     "require-dev": {
-        "orchestra/testbench": "~3.3.0|~3.4.0|~3.5.x-dev",
+        "orchestra/testbench": "~3.3.0|~3.4.0|~3.5.x-dev|~3.5.x-dev",
         "phpunit/phpunit": "^6.2",
         "spatie/phpunit-snapshot-assertions": "^0.4.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -24,14 +24,14 @@
         }
     ],
     "require": {
-        "php" : "^7.0",
-        "illuminate/support": "~5.1.0|~5.2.0|~5.3.0|~5.4.0",
+        "php": "^7.0",
+        "illuminate/support": "~5.1.0|~5.2.0|~5.3.0|~5.4.0|~5.5.x-dev",
         "nesbot/carbon": "^1.0",
         "spatie/phpunit-snapshot-assertions": "^0.4.1"
     },
     "require-dev": {
-        "orchestra/testbench": "~3.3.0|~3.4.0",
-        "phpunit/phpunit": "^5.7",
+        "orchestra/testbench": "~3.3.0|~3.4.0|~3.5.x-dev",
+        "phpunit/phpunit": "^6.2",
         "spatie/phpunit-snapshot-assertions": "^0.4.1"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -25,12 +25,12 @@
     ],
     "require": {
         "php": "^7.0",
-        "illuminate/support": "~5.1.0|~5.2.0|~5.3.0|~5.4.0|~5.5.x-dev|~5.5.x-dev",
+        "illuminate/support": "~5.1.0|~5.2.0|~5.3.0|~5.4.0|~5.5.x-dev",
         "nesbot/carbon": "^1.0",
         "spatie/phpunit-snapshot-assertions": "^0.4.1"
     },
     "require-dev": {
-        "orchestra/testbench": "~3.3.0|~3.4.0|~3.5.x-dev|~3.5.x-dev",
+        "orchestra/testbench": "~3.3.0|~3.4.0|~3.5.x-dev",
         "phpunit/phpunit": "^6.2",
         "spatie/phpunit-snapshot-assertions": "^0.4.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -25,12 +25,12 @@
     ],
     "require": {
         "php": "^7.0",
-        "illuminate/support": "~5.1.0|~5.2.0|~5.3.0|~5.4.0|~5.5.x-dev|~5.5.x-dev",
+        "illuminate/support": "~5.1.0|~5.2.0|~5.3.0|~5.4.0|~5.5.x-dev|~5.5.x-dev|~5.5.x-dev",
         "nesbot/carbon": "^1.0",
         "spatie/phpunit-snapshot-assertions": "^0.4.1"
     },
     "require-dev": {
-        "orchestra/testbench": "~3.3.0|~3.4.0|~3.5.x-dev|~3.5.x-dev",
+        "orchestra/testbench": "~3.3.0|~3.4.0|~3.5.x-dev|~3.5.x-dev|~3.5.x-dev",
         "phpunit/phpunit": "^6.2",
         "spatie/phpunit-snapshot-assertions": "^0.4.1"
     },
@@ -55,3 +55,4 @@
         }
     }
 }
+


### PR DESCRIPTION
This Pull-Requests help you to prepare your Package for Laravel 5.5. I've tested it automated and this was the PHPUnit Result:
PHPUnit 6.3-dev by Sebastian Bergmann and contributors.

Runtime:       PHP 7.1.7 with Xdebug 2.5.5
Configuration: /Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-feed/phpunit.xml.dist

....                                                                4 / 4 (100%)

Time: 993 ms, Memory: 12.00MB

OK (4 tests, 8 assertions)

Generating code coverage report in Clover XML format ... done

Generating code coverage report in HTML format ... done

Nice looks really good! There are no Errors so it might work in Laravel 5.5 without any adjustments