### PR TITLE
Added support for Laravel 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,11 +25,11 @@
     ],
     "require": {
         "php" : "^7.0",
-        "illuminate/support": "~5.1.0|~5.2.0|~5.3.0|~5.4.0",
+        "illuminate/support": "~5.1.0|~5.2.0|~5.3.0|~5.4.0|~5.5.0",
         "nesbot/carbon": "^1.0"
     },
     "require-dev": {
-        "orchestra/testbench": "~3.3.0|~3.4.0",
+        "orchestra/testbench": "~3.3.0|~3.4.0|~3.5.0",
         "phpunit/phpunit": "^5.7",
         "spatie/phpunit-snapshot-assertions": "^0.4.1"
     },


### PR DESCRIPTION
I saw that you added support for auto discovery, but forgot to add support for Laravel 5.5 in composer.json. That's why my installation failed on my 5.5 project.