### PR TITLE
Added the ability to use custom views for the feed items.

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,13 @@ return [
             'url' => '/feed',
 
             'title' => 'All newsitems on mysite.com',
+
+            /*
+             * Custom view for the items.
+             *
+             * Defaults to feed::feed if not present.
+             */
+            'view' => 'feed::feed',
         ],
     ],
 
@@ -197,6 +204,39 @@ The `items` key must point to a method that returns one of the following:
 - An array or collection of `Feedable`s
 - An array or collection of `FeedItem`s
 - An array or collection of arrays containing feed item values
+
+### Customizing your feed views
+
+This package provides, out of the box, the `feed::feed` view that displays your feeds details.
+
+However, you could use a custom view per feed by providing a `view` key inside of your feed configuration.
+
+In the following example, we're using the previous `News` feed with a custom `feeds.news` view (located on `resources/views/feeds/news.blade.php`):
+
+```php
+// config/feed.php
+
+return [
+
+    'feeds' => [
+        'news' => [
+            'items' => 'App\NewsItem@getFeedItems',
+
+            'url' => '/feed',
+
+            'title' => 'All newsitems on mysite.com',
+
+            /*
+             * Custom view for the items.
+             *
+             * Defaults to feed::feed if not present.
+             */
+            'view' => 'feeds.news',
+        ],
+    ],
+
+];
+```
 
 ### Automatically generate feed links
 

--- a/config/feed.php
+++ b/config/feed.php
@@ -20,6 +20,13 @@ return [
             'url' => '',
 
             'title' => 'My feed',
+
+            /**
+             * Custom view for the items.
+             *
+             * Defaults to feed::feed if not present.
+             */
+            'view' => 'feed::feed',
         ],
     ],
 

--- a/config/feed.php
+++ b/config/feed.php
@@ -21,7 +21,7 @@ return [
 
             'title' => 'My feed',
 
-            /**
+            /*
              * Custom view for the items.
              *
              * Defaults to feed::feed if not present.

--- a/src/Feed.php
+++ b/src/Feed.php
@@ -15,13 +15,17 @@ class Feed implements Responsable
     /** @var string */
     protected $url;
 
+    /** @var string */
+    protected $view;
+
     /** @var \Illuminate\Support\Collection */
     protected $items;
 
-    public function __construct($title, $url, $resolver)
+    public function __construct($title, $url, $resolver, $view)
     {
         $this->title = $title;
         $this->url = $url;
+        $this->view = $view;
 
         $this->items = $this->resolveItems($resolver);
     }
@@ -35,7 +39,7 @@ class Feed implements Responsable
             'updated' => $this->lastUpdated(),
         ];
 
-        $contents = view('feed::feed', [
+        $contents = view($this->view, [
             'meta' => $meta,
             'items' => $this->items,
         ]);

--- a/src/Http/FeedController.php
+++ b/src/Http/FeedController.php
@@ -16,6 +16,6 @@ class FeedController
 
         abort_unless($feed, 404);
 
-        return new Feed($feed['title'], request()->url(), $feed['items']);
+        return new Feed($feed['title'], request()->url(), $feed['items'], $feed['view'] ?? 'feed::feed');
     }
 }

--- a/tests/FeedTest.php
+++ b/tests/FeedTest.php
@@ -32,4 +32,13 @@ class FeedTest extends TestCase
 
         $this->assertMatchesSnapshot($feedLinksHtml);
     }
+
+    /** @test */
+    function all_feed_items_can_have_a_custom_view()
+    {
+        $response = $this->get("/feedBaseUrl/feed-with-custom-view");
+
+        $response->assertStatus(200);
+        $response->assertViewIs('feed::links');
+    }
 }

--- a/tests/FeedTest.php
+++ b/tests/FeedTest.php
@@ -34,9 +34,9 @@ class FeedTest extends TestCase
     }
 
     /** @test */
-    function all_feed_items_can_have_a_custom_view()
+    public function all_feed_items_can_have_a_custom_view()
     {
-        $response = $this->get("/feedBaseUrl/feed-with-custom-view");
+        $response = $this->get('/feedBaseUrl/feed-with-custom-view');
 
         $response->assertStatus(200);
         $response->assertViewIs('feed::links');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -50,6 +50,13 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
                 'title' => 'Feed 3',
                 'description' => 'This is feed 3 from the unit tests',
             ],
+            [
+                'items' => 'Spatie\Feed\Test\DummyRepository@getAll',
+                'url' => '/feed-with-custom-view',
+                'title' => 'Feed with Custom View',
+                'description' => 'This is a feed that uses custom views from the unit tests',
+                'view' => 'feed::links',
+            ],
         ];
 
         $app['config']->set('feed.feeds', $feed);

--- a/tests/__snapshots__/FeedTest__it_can_render_all_feed_links_via_a_view__1.php
+++ b/tests/__snapshots__/FeedTest__it_can_render_all_feed_links_via_a_view__1.php
@@ -1,4 +1,5 @@
 <?php return '<link rel="alternate" type="application/rss+xml" href="http://localhost/feedBaseUrl/feed1" title="Feed 1">
     <link rel="alternate" type="application/rss+xml" href="http://localhost/feedBaseUrl/feed2" title="Feed 2">
     <link rel="alternate" type="application/rss+xml" href="http://localhost/feedBaseUrl/feed3" title="Feed 3">
+    <link rel="alternate" type="application/rss+xml" href="http://localhost/feedBaseUrl/feed-with-custom-view" title="Feed with Custom View">
 ';


### PR DESCRIPTION
This is a PR for #63.

I've added a new optional property in the feed configuration named `view`. If this property is not passed, then by default, we load the `feed::feed` view.

The `view` argument was also added to the Feed constructor in order to later be used on the `toResponse` method (to generate the proper view).

I'm looking forward to hear your feedback, and if you find any issues, I'll gladly try to fix them. :)