### PR TITLE
Support for Signed URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ return [
              * The view that will render the feed.
              */
             'view' => 'feed::feed',
+
+            /*
+             * The feed will be assigned the signed middleware.
+             * Only available for Laravel 5.6+
+             *
+             * Defaults to false if not present.
+             */
+            'signed' => false,
         ],
     ],
 ];
@@ -196,6 +204,14 @@ return [
              * Defaults to feed::feed if not present.
              */
             'view' => 'feed::feed',
+
+            /*
+             * The feed will be assigned the signed middleware.
+             * Only available for Laravel 5.6+
+             *
+             * Defaults to false if not present.
+             */
+            'signed' => false,
         ],
     ],
 
@@ -254,6 +270,48 @@ You can add this to your `<head>` through a partial view.
 ```php
  @include('feed::links')
 ```
+
+### Create protected feeds
+
+Laravel 5.6+ allows you to create "signed" URLs to named routes. With this you can create routes that are only accessible with a "signature" hash.
+
+For example you can create feeds for authorized clients where they can see their private news feed.
+
+Here you can see a configuration as an example:
+
+```php
+// config/feed.php
+
+return [
+
+    'feeds' => [
+        'signed' => [
+            'items' => 'App\NewsItem@getUserFeedItems',
+
+            'url' => '/feed/{user}',
+
+            'title' => 'All newsitems on mysite.com',
+
+            /*
+             * The feed will be assigned the signed middleware.
+             * Only available for Laravel 5.6+
+             *
+             * Defaults to false if not present.
+             */
+            'signed' => true,
+        ],
+    ],
+
+];
+```
+
+If the url has parameters, you cannot use the included partial.
+ 
+```html
+<link rel="alternate" type="application/atom+xml" title="News" href="{{ url()->signedRoute("feeds.signed", [auth()->id()]) }}">
+```
+
+To access the route parameters you can use the Request facade or add `Illuminate\Http\Request` to the parameter list of your item handler.
 
 ## Changelog
 

--- a/config/feed.php
+++ b/config/feed.php
@@ -24,6 +24,14 @@ return [
              * The view that will render the feed.
              */
             'view' => 'feed::feed',
+
+            /*
+             * The feed will be assigned the signed middleware.
+             * Only available for Laravel 5.6+
+             *
+             * Defaults to false if not present.
+             */
+            'signed' => false,
         ],
     ],
 ];

--- a/src/FeedServiceProvider.php
+++ b/src/FeedServiceProvider.php
@@ -42,7 +42,7 @@ class FeedServiceProvider extends ServiceProvider
                 $route = $router->get($url, '\\'.FeedController::class)->name("feeds.{$name}");
 
                 if (array_key_exists('signed', $configuration) && $configuration['signed']) {
-                    $route->middleware('signed');
+                    $route->middleware(\Illuminate\Routing\Middleware\ValidateSignature::class);
                 }
             }
         });

--- a/src/FeedServiceProvider.php
+++ b/src/FeedServiceProvider.php
@@ -39,7 +39,11 @@ class FeedServiceProvider extends ServiceProvider
             foreach (config('feed.feeds') as $name => $configuration) {
                 $url = Path::merge($baseUrl, $configuration['url']);
 
-                $router->get($url, '\\'.FeedController::class)->name("feeds.{$name}");
+                $route = $router->get($url, '\\'.FeedController::class)->name("feeds.{$name}");
+
+                if (array_key_exists('signed', $configuration) && $configuration['signed']) {
+                    $route->middleware('signed');
+                }
             }
         });
     }
@@ -53,7 +57,9 @@ class FeedServiceProvider extends ServiceProvider
 
     protected function feeds()
     {
-        return collect(config('feed.feeds'))->mapWithKeys(function ($feed, $name) {
+        return collect(config('feed.feeds'))->filter(function ($feed) {
+            return ! ($feed['signed'] ?? false);
+        })->mapWithKeys(function ($feed, $name) {
             return [$name => $feed['title']];
         });
     }

--- a/tests/FeedTest.php
+++ b/tests/FeedTest.php
@@ -45,7 +45,10 @@ class FeedTest extends TestCase
         $response->assertViewIs('feed::links');
     }
 
-    /** @test */
+    /**
+     * @test
+     * @requires function \Illuminate\Routing\Middleware\ValidateSignature::handle
+     */
     public function feed_is_assigned_the_signed_middleware()
     {
         $this->disableExceptionHandling();

--- a/tests/FeedTest.php
+++ b/tests/FeedTest.php
@@ -2,6 +2,8 @@
 
 namespace Spatie\Feed\Test;
 
+use Illuminate\Routing\Exceptions\InvalidSignatureException;
+
 class FeedTest extends TestCase
 {
     /** @var array */
@@ -41,5 +43,17 @@ class FeedTest extends TestCase
         $response->assertStatus(200);
 
         $response->assertViewIs('feed::links');
+    }
+
+    /** @test */
+    public function feed_is_assigned_the_signed_middleware()
+    {
+        $this->disableExceptionHandling();
+
+        try {
+            $this->get('/feedBaseUrl/feed-signed');
+        } catch (InvalidSignatureException $e) {
+            $this->assertEquals(403, $e->getStatusCode());
+        }
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -57,6 +57,13 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
                 'description' => 'This is a feed that uses custom views from the unit tests',
                 'view' => 'feed::links',
             ],
+            [
+                'items' => ['Spatie\Feed\Test\DummyRepository@getAll'],
+                'url' => '/feed-signed',
+                'title' => 'Signed Feed',
+                'description' => 'This is a feed which is protected with signed middleware',
+                'signed' => true,
+            ],
         ];
 
         $app['config']->set('feed.feeds', $feed);


### PR DESCRIPTION
Hi,

This is a PR for #80.

During the implementation I ran into two limitations.

1. Passing parameters to the `route` method inside the links partial is a bit tricky and I did not want to mess things up.
2. As I checked the route parameters currently not accessible from the items handler.

Feel free to correct me if I'm wrong.