### PR TITLE
feat: custom feed sorting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 composer.lock
 docs
 vendor
+.phpunit.result.cache

--- a/config/feed.php
+++ b/config/feed.php
@@ -24,6 +24,11 @@ return [
              * The view that will render the feed.
              */
             'view' => 'feed::feed',
+
+            /*
+             * The model field that the feed should be sorted bys
+             */
+            'sort_by' => 'updated',
         ],
     ],
 ];

--- a/src/Http/FeedController.php
+++ b/src/Http/FeedController.php
@@ -17,6 +17,12 @@ class FeedController
 
         abort_unless($feed, 404);
 
-        return new Feed($feed['title'], request()->url(), $feed['items'], $feed['view'] ?? 'feed::feed');
+        return new Feed(
+            $feed['title'],
+            request()->url(),
+            $feed['items'],
+            $feed['view'] ?? 'feed::feed',
+            $feed['sort_by'] ?? Feed::SORT_KEY_UPDATED
+        );
     }
 }

--- a/tests/DummyItem.php
+++ b/tests/DummyItem.php
@@ -8,13 +8,24 @@ use Spatie\Feed\FeedItem;
 
 class DummyItem implements Feedable
 {
+    /** @var int */
+    private $id;
+    /** @var Carbon */
+    private $updated;
+
+    public function __construct(int $id, Carbon $updated)
+    {
+        $this->id = $id;
+        $this->updated = $updated;
+    }
+
     public function toFeedItem()
     {
         return new FeedItem([
-            'id' => 1,
+            'id' => $this->id,
             'title' => 'feedItemTitle',
             'summary' => 'feedItemSummary',
-            'updated' => Carbon::now(),
+            'updated' => $this->updated,
             'link' => 'https://localhost/news/testItem1',
             'author' => 'feedItemAuthor',
         ]);

--- a/tests/DummyRepository.php
+++ b/tests/DummyRepository.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Feed\Test;
 
+use Carbon\Carbon;
 use Illuminate\Support\Collection;
 
 class DummyRepository
@@ -12,11 +13,11 @@ class DummyRepository
     public function __construct()
     {
         $this->items = collect([
-            new DummyItem(),
-            new DummyItem(),
-            new DummyItem(),
-            new DummyItem(),
-            new DummyItem(),
+            new DummyItem(1, Carbon::create(2016, 1, 5, 0, 0, 0)->setTimezone('Europe/Brussels')->startOfDay()),
+            new DummyItem(2, Carbon::create(2016, 1, 4, 0, 0, 0)->setTimezone('Europe/Brussels')->startOfDay()),
+            new DummyItem(3, Carbon::create(2016, 1, 3, 0, 0, 0)->setTimezone('Europe/Brussels')->startOfDay()),
+            new DummyItem(4, Carbon::create(2016, 1, 2, 0, 0, 0)->setTimezone('Europe/Brussels')->startOfDay()),
+            new DummyItem(5, Carbon::create(2016, 1, 1, 0, 0, 0)->setTimezone('Europe/Brussels')->startOfDay()),
         ]);
     }
 

--- a/tests/FeedTest.php
+++ b/tests/FeedTest.php
@@ -5,7 +5,7 @@ namespace Spatie\Feed\Test;
 class FeedTest extends TestCase
 {
     /** @var array */
-    protected $feedNames = ['feed1', 'feed2', 'feed3'];
+    protected $feedNames = ['feed1', 'feed2', 'feed3', 'feed4'];
 
     /** @test */
     public function all_feeds_are_available_on_their_registered_routes()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,7 +3,6 @@
 namespace Spatie\Feed\Test;
 
 use Exception;
-use Carbon\Carbon;
 use Spatie\Feed\FeedServiceProvider;
 use Spatie\Snapshots\MatchesSnapshots;
 use Illuminate\Foundation\Exceptions\Handler;
@@ -15,10 +14,6 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
 
     public function setUp() : void
     {
-        Carbon::setTestNow(Carbon::create(2016, 1, 1, 0, 0, 0)
-            ->setTimezone('Europe/Brussels')
-            ->startOfDay());
-
         parent::setUp();
 
         $this->disableExceptionHandling();
@@ -49,6 +44,13 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
                 'url' => '/feed3',
                 'title' => 'Feed 3',
                 'description' => 'This is feed 3 from the unit tests',
+            ],
+            [
+                'items' => ['Spatie\Feed\Test\DummyRepository@getAllWithArguments', 'first'],
+                'url' => '/feed4',
+                'title' => 'Feed 4',
+                'sort_by' => 'id',
+                'description' => 'This feed is sorted by `id` rather than the default `updated`',
             ],
             [
                 'items' => 'Spatie\Feed\Test\DummyRepository@getAll',

--- a/tests/__snapshots__/FeedTest__all_feed_items_have_expected_data__2.php
+++ b/tests/__snapshots__/FeedTest__all_feed_items_have_expected_data__2.php
@@ -3,7 +3,7 @@
                         <id>http://localhost/feedBaseUrl/feed2</id>
                                 <link href="http://localhost/feedBaseUrl/feed2"></link>
                                 <title><![CDATA[Feed 2]]></title>
-                                <updated>2016-01-01T00:00:00+01:00</updated>
+                                <updated>2016-01-05T00:00:00+01:00</updated>
                         <entry>
             <title><![CDATA[feedItemTitle]]></title>
             <link rel="alternate" href="https://localhost/news/testItem1" />
@@ -14,48 +14,48 @@
             <summary type="html">
                 <![CDATA[feedItemSummary]]>
             </summary>
-            <updated>2016-01-01T00:00:00+01:00</updated>
+            <updated>2016-01-05T00:00:00+01:00</updated>
         </entry>
             <entry>
             <title><![CDATA[feedItemTitle]]></title>
             <link rel="alternate" href="https://localhost/news/testItem1" />
-            <id>http://localhost/1</id>
+            <id>http://localhost/2</id>
             <author>
                 <name> <![CDATA[feedItemAuthor]]></name>
             </author>
             <summary type="html">
                 <![CDATA[feedItemSummary]]>
             </summary>
-            <updated>2016-01-01T00:00:00+01:00</updated>
+            <updated>2016-01-04T00:00:00+01:00</updated>
         </entry>
             <entry>
             <title><![CDATA[feedItemTitle]]></title>
             <link rel="alternate" href="https://localhost/news/testItem1" />
-            <id>http://localhost/1</id>
+            <id>http://localhost/3</id>
             <author>
                 <name> <![CDATA[feedItemAuthor]]></name>
             </author>
             <summary type="html">
                 <![CDATA[feedItemSummary]]>
             </summary>
-            <updated>2016-01-01T00:00:00+01:00</updated>
+            <updated>2016-01-03T00:00:00+01:00</updated>
         </entry>
             <entry>
             <title><![CDATA[feedItemTitle]]></title>
             <link rel="alternate" href="https://localhost/news/testItem1" />
-            <id>http://localhost/1</id>
+            <id>http://localhost/4</id>
             <author>
                 <name> <![CDATA[feedItemAuthor]]></name>
             </author>
             <summary type="html">
                 <![CDATA[feedItemSummary]]>
             </summary>
-            <updated>2016-01-01T00:00:00+01:00</updated>
+            <updated>2016-01-02T00:00:00+01:00</updated>
         </entry>
             <entry>
             <title><![CDATA[feedItemTitle]]></title>
             <link rel="alternate" href="https://localhost/news/testItem1" />
-            <id>http://localhost/1</id>
+            <id>http://localhost/5</id>
             <author>
                 <name> <![CDATA[feedItemAuthor]]></name>
             </author>

--- a/tests/__snapshots__/FeedTest__all_feed_items_have_expected_data__3.php
+++ b/tests/__snapshots__/FeedTest__all_feed_items_have_expected_data__3.php
@@ -3,7 +3,7 @@
                         <id>http://localhost/feedBaseUrl/feed3</id>
                                 <link href="http://localhost/feedBaseUrl/feed3"></link>
                                 <title><![CDATA[Feed 3]]></title>
-                                <updated>2016-01-01T00:00:00+01:00</updated>
+                                <updated>2016-01-05T00:00:00+01:00</updated>
                         <entry>
             <title><![CDATA[feedItemTitle]]></title>
             <link rel="alternate" href="https://localhost/news/testItem1" />
@@ -14,48 +14,48 @@
             <summary type="html">
                 <![CDATA[feedItemSummary]]>
             </summary>
-            <updated>2016-01-01T00:00:00+01:00</updated>
+            <updated>2016-01-05T00:00:00+01:00</updated>
         </entry>
             <entry>
             <title><![CDATA[feedItemTitle]]></title>
             <link rel="alternate" href="https://localhost/news/testItem1" />
-            <id>http://localhost/1</id>
+            <id>http://localhost/2</id>
             <author>
                 <name> <![CDATA[feedItemAuthor]]></name>
             </author>
             <summary type="html">
                 <![CDATA[feedItemSummary]]>
             </summary>
-            <updated>2016-01-01T00:00:00+01:00</updated>
+            <updated>2016-01-04T00:00:00+01:00</updated>
         </entry>
             <entry>
             <title><![CDATA[feedItemTitle]]></title>
             <link rel="alternate" href="https://localhost/news/testItem1" />
-            <id>http://localhost/1</id>
+            <id>http://localhost/3</id>
             <author>
                 <name> <![CDATA[feedItemAuthor]]></name>
             </author>
             <summary type="html">
                 <![CDATA[feedItemSummary]]>
             </summary>
-            <updated>2016-01-01T00:00:00+01:00</updated>
+            <updated>2016-01-03T00:00:00+01:00</updated>
         </entry>
             <entry>
             <title><![CDATA[feedItemTitle]]></title>
             <link rel="alternate" href="https://localhost/news/testItem1" />
-            <id>http://localhost/1</id>
+            <id>http://localhost/4</id>
             <author>
                 <name> <![CDATA[feedItemAuthor]]></name>
             </author>
             <summary type="html">
                 <![CDATA[feedItemSummary]]>
             </summary>
-            <updated>2016-01-01T00:00:00+01:00</updated>
+            <updated>2016-01-02T00:00:00+01:00</updated>
         </entry>
             <entry>
             <title><![CDATA[feedItemTitle]]></title>
             <link rel="alternate" href="https://localhost/news/testItem1" />
-            <id>http://localhost/1</id>
+            <id>http://localhost/5</id>
             <author>
                 <name> <![CDATA[feedItemAuthor]]></name>
             </author>

--- a/tests/__snapshots__/FeedTest__all_feed_items_have_expected_data__4.php
+++ b/tests/__snapshots__/FeedTest__all_feed_items_have_expected_data__4.php
@@ -1,44 +1,20 @@
 <?php return '<?xml version="1.0" encoding="UTF-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
-                        <id>http://localhost/feedBaseUrl/feed1</id>
-                                <link href="http://localhost/feedBaseUrl/feed1"></link>
-                                <title><![CDATA[Feed 1]]></title>
+                        <id>http://localhost/feedBaseUrl/feed4</id>
+                                <link href="http://localhost/feedBaseUrl/feed4"></link>
+                                <title><![CDATA[Feed 4]]></title>
                                 <updated>2016-01-05T00:00:00+01:00</updated>
                         <entry>
             <title><![CDATA[feedItemTitle]]></title>
             <link rel="alternate" href="https://localhost/news/testItem1" />
-            <id>http://localhost/1</id>
+            <id>http://localhost/5</id>
             <author>
                 <name> <![CDATA[feedItemAuthor]]></name>
             </author>
             <summary type="html">
                 <![CDATA[feedItemSummary]]>
             </summary>
-            <updated>2016-01-05T00:00:00+01:00</updated>
-        </entry>
-            <entry>
-            <title><![CDATA[feedItemTitle]]></title>
-            <link rel="alternate" href="https://localhost/news/testItem1" />
-            <id>http://localhost/2</id>
-            <author>
-                <name> <![CDATA[feedItemAuthor]]></name>
-            </author>
-            <summary type="html">
-                <![CDATA[feedItemSummary]]>
-            </summary>
-            <updated>2016-01-04T00:00:00+01:00</updated>
-        </entry>
-            <entry>
-            <title><![CDATA[feedItemTitle]]></title>
-            <link rel="alternate" href="https://localhost/news/testItem1" />
-            <id>http://localhost/3</id>
-            <author>
-                <name> <![CDATA[feedItemAuthor]]></name>
-            </author>
-            <summary type="html">
-                <![CDATA[feedItemSummary]]>
-            </summary>
-            <updated>2016-01-03T00:00:00+01:00</updated>
+            <updated>2016-01-01T00:00:00+01:00</updated>
         </entry>
             <entry>
             <title><![CDATA[feedItemTitle]]></title>
@@ -55,14 +31,38 @@
             <entry>
             <title><![CDATA[feedItemTitle]]></title>
             <link rel="alternate" href="https://localhost/news/testItem1" />
-            <id>http://localhost/5</id>
+            <id>http://localhost/3</id>
             <author>
                 <name> <![CDATA[feedItemAuthor]]></name>
             </author>
             <summary type="html">
                 <![CDATA[feedItemSummary]]>
             </summary>
-            <updated>2016-01-01T00:00:00+01:00</updated>
+            <updated>2016-01-03T00:00:00+01:00</updated>
+        </entry>
+            <entry>
+            <title><![CDATA[feedItemTitle]]></title>
+            <link rel="alternate" href="https://localhost/news/testItem1" />
+            <id>http://localhost/2</id>
+            <author>
+                <name> <![CDATA[feedItemAuthor]]></name>
+            </author>
+            <summary type="html">
+                <![CDATA[feedItemSummary]]>
+            </summary>
+            <updated>2016-01-04T00:00:00+01:00</updated>
+        </entry>
+            <entry>
+            <title><![CDATA[feedItemTitle]]></title>
+            <link rel="alternate" href="https://localhost/news/testItem1" />
+            <id>http://localhost/1</id>
+            <author>
+                <name> <![CDATA[feedItemAuthor]]></name>
+            </author>
+            <summary type="html">
+                <![CDATA[feedItemSummary]]>
+            </summary>
+            <updated>2016-01-05T00:00:00+01:00</updated>
         </entry>
     </feed>
 ';

--- a/tests/__snapshots__/FeedTest__it_can_render_all_feed_links_via_a_view__1.php
+++ b/tests/__snapshots__/FeedTest__it_can_render_all_feed_links_via_a_view__1.php
@@ -1,5 +1,6 @@
 <?php return '<link rel="alternate" type="application/rss+xml" href="http://localhost/feedBaseUrl/feed1" title="Feed 1">
     <link rel="alternate" type="application/rss+xml" href="http://localhost/feedBaseUrl/feed2" title="Feed 2">
     <link rel="alternate" type="application/rss+xml" href="http://localhost/feedBaseUrl/feed3" title="Feed 3">
+    <link rel="alternate" type="application/rss+xml" href="http://localhost/feedBaseUrl/feed4" title="Feed 4">
     <link rel="alternate" type="application/rss+xml" href="http://localhost/feedBaseUrl/feed-with-custom-view" title="Feed with Custom View">
 ';


### PR DESCRIPTION
As per https://github.com/spatie/laravel-feed/issues/71

- Updated config to add `sort_by` option, defaulted to `updated`
- Added `sortKey` property to the `Feed` class, as well as a `sortByDesc()` method that sorts by a given key
- Updated tests