### PR TITLE
Support dynamic required fields

### DIFF
--- a/config/feed.php
+++ b/config/feed.php
@@ -23,6 +23,11 @@ return [
             'language' => 'en-US',
 
             /*
+             * Required fields every feed item must contain.
+             */
+            'requiredFields' => ['id', 'title', 'updated', 'summary', 'link', 'author'],
+
+            /*
              * The view that will render the feed.
              */
             'view' => 'feed::feed',

--- a/src/Feed.php
+++ b/src/Feed.php
@@ -11,6 +11,9 @@ use Illuminate\Contracts\Support\Responsable;
 class Feed implements Responsable
 {
     /** @var string */
+    protected $name;
+
+    /** @var string */
     protected $title;
 
     /** @var string */
@@ -28,8 +31,9 @@ class Feed implements Responsable
     /** @var \Illuminate\Support\Collection */
     protected $items;
 
-    public function __construct($title, $url, $resolver, $view, $description, $language)
+    public function __construct($name, $title, $url, $resolver, $view, $description, $language)
     {
+        $this->name = $name;
         $this->title = $title;
         $this->description = $description;
         $this->language = $language;
@@ -80,7 +84,7 @@ class Feed implements Responsable
         }
 
         if ($feedable instanceof FeedItem) {
-            $feedable->validate();
+            $feedable->validate($this->name);
 
             return $feedable;
         }
@@ -95,7 +99,7 @@ class Feed implements Responsable
             throw InvalidFeedItem::notAFeedItem($feedItem);
         }
 
-        $feedItem->validate();
+        $feedItem->validate($this->name);
 
         return $feedItem;
     }

--- a/src/FeedItem.php
+++ b/src/FeedItem.php
@@ -120,9 +120,9 @@ class FeedItem
         return $this;
     }
 
-    public function validate()
+    public function validate($feedName)
     {
-        $requiredFields = ['id', 'title', 'updated', 'summary', 'link', 'author'];
+        $requiredFields = config("feed.feeds.{$feedName}.requiredFields", []);
 
         foreach ($requiredFields as $requiredField) {
             if (is_null($this->$requiredField)) {

--- a/src/Http/FeedController.php
+++ b/src/Http/FeedController.php
@@ -18,6 +18,7 @@ class FeedController
         abort_unless($feed, 404);
 
         return new Feed(
+            $name,
             $feed['title'],
             request()->url(),
             $feed['items'],

--- a/tests/FeedItemTest.php
+++ b/tests/FeedItemTest.php
@@ -12,6 +12,6 @@ class FeedItemTest extends TestCase
     {
         $this->expectException(InvalidFeedItem::class);
 
-        FeedItem::create()->validate();
+        FeedItem::create()->validate('Feed 1');
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -32,28 +32,29 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
     protected function getEnvironmentSetUp($app)
     {
         $feed = [
-            [
+            'Feed 1' => [
                 'items' => 'Spatie\Feed\Test\DummyRepository@getAll',
                 'url' => '/feed1',
                 'title' => 'Feed 1',
                 'description' => 'This is feed 1 from the unit tests',
                 'language' => 'en-US',
+                'requiredFields' => ['id', 'title', 'updated', 'summary', 'link', 'author'],
             ],
-            [
+            'Feed 2' => [
                 'items' => 'Spatie\Feed\Test\DummyRepository@getAll',
                 'url' => '/feed2',
                 'title' => 'Feed 2',
                 'description' => 'This is feed 2 from the unit tests',
                 'language' => 'en-US',
             ],
-            [
+            'Feed 3' => [
                 'items' => ['Spatie\Feed\Test\DummyRepository@getAllWithArguments', 'first'],
                 'url' => '/feed3',
                 'title' => 'Feed 3',
                 'description' => 'This is feed 3 from the unit tests',
                 'language' => 'en-US',
             ],
-            [
+            'Feed 4' => [
                 'items' => 'Spatie\Feed\Test\DummyRepository@getAll',
                 'url' => '/feed-with-custom-view',
                 'title' => 'Feed with Custom View',


### PR DESCRIPTION
As already mentioned in #102 this PR tries to make this package more dynamic by specifying the required fields of a feed item in the config instead of hardcoding them.

For this first draft, I didn't want to change the behavior of the package too much so I made this pretty hacky version where we pass the feed name to the feed item to get all required fields from the config.

I am not sure if the `validate` method should be moved to the feed. This way we can prevent passing the feed name to the item.

Please let me know what you think about it.