### PR TITLE
Remove Feedable type hint

### DIFF
--- a/src/Feed.php
+++ b/src/Feed.php
@@ -35,7 +35,7 @@ class Feed implements Responsable
         $this->url = $url ?? request()->url();
         $this->view = $view;
 
-        $this->feedItems = $items->map(fn (Feedable $feedable) => $this->castToFeedItem($feedable));
+        $this->feedItems = $items->map(fn ($feedable) => $this->castToFeedItem($feedable));
     }
 
     public function toResponse($request): Response

--- a/src/Feed.php
+++ b/src/Feed.php
@@ -59,7 +59,7 @@ class Feed implements Responsable
         ]);
     }
 
-    protected function castToFeedItem(Feedable $feedable): FeedItem
+    protected function castToFeedItem($feedable): FeedItem
     {
         if (is_array($feedable)) {
             $feedable = new FeedItem($feedable);

--- a/src/ResolveFeedItems.php
+++ b/src/ResolveFeedItems.php
@@ -15,6 +15,6 @@ class ResolveFeedItems
             $resolver
         );
 
-        return collect($items)->map(fn (Feedable $feedable) => $this->castToFeedItem($feedable));
+        return collect($items)->map(fn ($feedable) => $this->castToFeedItem($feedable));
     }
 }

--- a/tests/DummyFeedItemRepository.php
+++ b/tests/DummyFeedItemRepository.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Spatie\Feed\Test;
+
+use Carbon\Carbon;
+use Spatie\Feed\FeedItem;
+use Illuminate\Support\Collection;
+
+class DummyFeedItemRepository
+{
+    /** @var \Illuminate\Support\Collection */
+    public $items;
+
+    public function __construct()
+    {
+        $this->items = collect([
+            new FeedItem([
+                'id' => 1,
+                'title' => 'feedItemTitle',
+                'summary' => 'feedItemSummary',
+                'enclosure' => 'http://localhost/image1.jpg',
+                'enclosureLength' => 31300,
+                'enclosureType' => 'image/jpeg',
+                'updated' => Carbon::now(),
+                'link' => 'https://localhost/news/testItem1',
+                'author' => 'feedItemAuthor',
+                'category' => 'feedItemCategory',
+            ]),
+            new FeedItem([
+                'id' => 1,
+                'title' => 'feedItemTitle',
+                'summary' => 'feedItemSummary',
+                'enclosure' => 'http://localhost/image1.jpg',
+                'enclosureLength' => 31300,
+                'enclosureType' => 'image/jpeg',
+                'updated' => Carbon::now(),
+                'link' => 'https://localhost/news/testItem1',
+                'author' => 'feedItemAuthor',
+                'category' => 'feedItemCategory',
+            ])
+        ]);
+    }
+
+    public function getAll(): Collection
+    {
+        return $this->items;
+    }
+}

--- a/tests/FeedTest.php
+++ b/tests/FeedTest.php
@@ -5,7 +5,7 @@ namespace Spatie\Feed\Test;
 class FeedTest extends TestCase
 {
     /** @var array */
-    protected $feedNames = ['feed1', 'feed2', 'feed3', 'feed1.rss'];
+    protected $feedNames = ['feed1', 'feed2', 'feed3', 'feed4', 'feed1.rss'];
 
     /** @test */
     public function all_feeds_are_available_on_their_registered_routes()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -51,6 +51,13 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
                 'language' => 'en-US',
             ],
             [
+                'items' => 'Spatie\Feed\Test\DummyFeedItemRepository@getAll',
+                'url' => '/feed4',
+                'title' => 'Feed 4',
+                'description' => 'This is feed 4 from the unit tests',
+                'language' => 'en-US',
+            ],
+            [
                 'items' => 'Spatie\Feed\Test\DummyRepository@getAll',
                 'url' => '/feed-with-custom-view',
                 'title' => 'Feed with Custom View',

--- a/tests/__snapshots__/FeedTest__all_feed_items_have_expected_data__4.txt
+++ b/tests/__snapshots__/FeedTest__all_feed_items_have_expected_data__4.txt
@@ -1,56 +1,41 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0">
-    <channel>
-        <title><![CDATA[Feed 1 RSS]]></title>
-        <link><![CDATA[http://localhost/feedBaseUrl/feed1.rss]]></link>
-        <description><![CDATA[This is feed 1 as RSS from the unit tests]]></description>
-        <language>en-US</language>
-        <pubDate>Fri, 01 Jan 2016 00:00:00 +0100</pubDate>
-
-                    <item>
-                <title><![CDATA[feedItemTitle]]></title>
-                <link>https://localhost/news/testItem1</link>
-                <description><![CDATA[feedItemSummary]]></description>
-                <author><![CDATA[feedItemAuthor]]></author>
-                <guid>http://localhost/1</guid>
-                <pubDate>Fri, 01 Jan 2016 00:00:00 +0100</pubDate>
-                                    <category>feedItemCategory</category>
-                            </item>
-                    <item>
-                <title><![CDATA[feedItemTitle]]></title>
-                <link>https://localhost/news/testItem1</link>
-                <description><![CDATA[feedItemSummary]]></description>
-                <author><![CDATA[feedItemAuthor]]></author>
-                <guid>http://localhost/1</guid>
-                <pubDate>Fri, 01 Jan 2016 00:00:00 +0100</pubDate>
-                                    <category>feedItemCategory</category>
-                            </item>
-                    <item>
-                <title><![CDATA[feedItemTitle]]></title>
-                <link>https://localhost/news/testItem1</link>
-                <description><![CDATA[feedItemSummary]]></description>
-                <author><![CDATA[feedItemAuthor]]></author>
-                <guid>http://localhost/1</guid>
-                <pubDate>Fri, 01 Jan 2016 00:00:00 +0100</pubDate>
-                                    <category>feedItemCategory</category>
-                            </item>
-                    <item>
-                <title><![CDATA[feedItemTitle]]></title>
-                <link>https://localhost/news/testItem1</link>
-                <description><![CDATA[feedItemSummary]]></description>
-                <author><![CDATA[feedItemAuthor]]></author>
-                <guid>http://localhost/1</guid>
-                <pubDate>Fri, 01 Jan 2016 00:00:00 +0100</pubDate>
-                                    <category>feedItemCategory</category>
-                            </item>
-                    <item>
-                <title><![CDATA[feedItemTitle]]></title>
-                <link>https://localhost/news/testItem1</link>
-                <description><![CDATA[feedItemSummary]]></description>
-                <author><![CDATA[feedItemAuthor]]></author>
-                <guid>http://localhost/1</guid>
-                <pubDate>Fri, 01 Jan 2016 00:00:00 +0100</pubDate>
-                                    <category>feedItemCategory</category>
-                            </item>
-            </channel>
-</rss>
+<feed xmlns="http://www.w3.org/2005/Atom">
+                        <id>http://localhost/feedBaseUrl/feed4</id>
+                                <link href="http://localhost/feedBaseUrl/feed4"></link>
+                                <title><![CDATA[Feed 4]]></title>
+                                <description>This is feed 4 from the unit tests</description>
+                                <language>en-US</language>
+                                <updated>Fri, 01 Jan 2016 00:00:00 +0100</updated>
+                        <entry>
+            <title><![CDATA[feedItemTitle]]></title>
+            <link rel="alternate" href="https://localhost/news/testItem1" />
+            <id>http://localhost/1</id>
+            <author>
+                <name> <![CDATA[feedItemAuthor]]></name>
+            </author>
+            <summary type="html">
+                <![CDATA[feedItemSummary]]>
+            </summary>
+                          <enclosure url="http://localhost/image1.jpg" length="31300" type="image/jpeg" />
+                                    <category type="html">
+                <![CDATA[feedItemCategory]]>
+            </category>
+                        <updated>Fri, 01 Jan 2016 00:00:00 +0100</updated>
+        </entry>
+            <entry>
+            <title><![CDATA[feedItemTitle]]></title>
+            <link rel="alternate" href="https://localhost/news/testItem1" />
+            <id>http://localhost/1</id>
+            <author>
+                <name> <![CDATA[feedItemAuthor]]></name>
+            </author>
+            <summary type="html">
+                <![CDATA[feedItemSummary]]>
+            </summary>
+                          <enclosure url="http://localhost/image1.jpg" length="31300" type="image/jpeg" />
+                                    <category type="html">
+                <![CDATA[feedItemCategory]]>
+            </category>
+                        <updated>Fri, 01 Jan 2016 00:00:00 +0100</updated>
+        </entry>
+    </feed>

--- a/tests/__snapshots__/FeedTest__all_feed_items_have_expected_data__5.txt
+++ b/tests/__snapshots__/FeedTest__all_feed_items_have_expected_data__5.txt
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+    <channel>
+        <title><![CDATA[Feed 1 RSS]]></title>
+        <link><![CDATA[http://localhost/feedBaseUrl/feed1.rss]]></link>
+        <description><![CDATA[This is feed 1 as RSS from the unit tests]]></description>
+        <language>en-US</language>
+        <pubDate>Fri, 01 Jan 2016 00:00:00 +0100</pubDate>
+
+                    <item>
+                <title><![CDATA[feedItemTitle]]></title>
+                <link>https://localhost/news/testItem1</link>
+                <description><![CDATA[feedItemSummary]]></description>
+                <author><![CDATA[feedItemAuthor]]></author>
+                <guid>http://localhost/1</guid>
+                <pubDate>Fri, 01 Jan 2016 00:00:00 +0100</pubDate>
+                                    <category>feedItemCategory</category>
+                            </item>
+                    <item>
+                <title><![CDATA[feedItemTitle]]></title>
+                <link>https://localhost/news/testItem1</link>
+                <description><![CDATA[feedItemSummary]]></description>
+                <author><![CDATA[feedItemAuthor]]></author>
+                <guid>http://localhost/1</guid>
+                <pubDate>Fri, 01 Jan 2016 00:00:00 +0100</pubDate>
+                                    <category>feedItemCategory</category>
+                            </item>
+                    <item>
+                <title><![CDATA[feedItemTitle]]></title>
+                <link>https://localhost/news/testItem1</link>
+                <description><![CDATA[feedItemSummary]]></description>
+                <author><![CDATA[feedItemAuthor]]></author>
+                <guid>http://localhost/1</guid>
+                <pubDate>Fri, 01 Jan 2016 00:00:00 +0100</pubDate>
+                                    <category>feedItemCategory</category>
+                            </item>
+                    <item>
+                <title><![CDATA[feedItemTitle]]></title>
+                <link>https://localhost/news/testItem1</link>
+                <description><![CDATA[feedItemSummary]]></description>
+                <author><![CDATA[feedItemAuthor]]></author>
+                <guid>http://localhost/1</guid>
+                <pubDate>Fri, 01 Jan 2016 00:00:00 +0100</pubDate>
+                                    <category>feedItemCategory</category>
+                            </item>
+                    <item>
+                <title><![CDATA[feedItemTitle]]></title>
+                <link>https://localhost/news/testItem1</link>
+                <description><![CDATA[feedItemSummary]]></description>
+                <author><![CDATA[feedItemAuthor]]></author>
+                <guid>http://localhost/1</guid>
+                <pubDate>Fri, 01 Jan 2016 00:00:00 +0100</pubDate>
+                                    <category>feedItemCategory</category>
+                            </item>
+            </channel>
+</rss>

--- a/tests/__snapshots__/FeedTest__it_can_render_all_feed_links_via_a_view__1.txt
+++ b/tests/__snapshots__/FeedTest__it_can_render_all_feed_links_via_a_view__1.txt
@@ -1,5 +1,6 @@
 <link rel="alternate" type="application/atom+xml" href="http://localhost/feedBaseUrl/feed1" title="Feed 1">
     <link rel="alternate" type="application/atom+xml" href="http://localhost/feedBaseUrl/feed2" title="Feed 2">
     <link rel="alternate" type="application/atom+xml" href="http://localhost/feedBaseUrl/feed3" title="Feed 3">
+    <link rel="alternate" type="application/atom+xml" href="http://localhost/feedBaseUrl/feed4" title="Feed 4">
     <link rel="alternate" type="application/atom+xml" href="http://localhost/feedBaseUrl/feed-with-custom-view" title="Feed with Custom View">
     <link rel="alternate" type="application/rss+xml" href="http://localhost/feedBaseUrl/feed1.rss" title="Feed 1 RSS">


### PR DESCRIPTION
I was trying to update my Blog to the latest laravel-feed release (3.0.0). I used the possibility to create my own feed items via a small "FeedGenerator" which basically just returns a Collection/Array of FeedItem.

Sample:

```
class FeedGenerator
{

    public function getItems()
    {
        return \Wink\WinkPost::with('tags')->live()->orderBy('publish_date', 'DESC')->get()->map(function ($post) {
            return FeedItem::create([
                'id' => $post->id,
                'title' => $post->title,
                'summary' => \Illuminate\Support\Str::limit(\Stevebauman\Purify\Facades\Purify::clean($post->content, ["HTML.Allowed" => '']),500),
                'updated' => $post->updated_at,
                'link' => route("blog.post",["slug" => $post->slug]),
                'author' =>  "Lukas Kämmerling",
            ]);
        });
    }
}
```

Within the config i used (as proposed from the ReadMe) the following value for `items`:
```
'items' => 'App\FeedGenerator@getItems',
```

With laravel-feed <3.0.0 this worked quite well. After the update i noticed the following error while accessing the /feed route i configured:

```
//TypeError
//Argument 1 passed to Spatie\Feed\Feed::Spatie\Feed\{closure}() must be an instance of Spatie\Feed\Feedable, instance of Spatie\Feed\FeedItem given
```

Of course i don't have a "Feedable" Instance there, because i already pass the FeedItem and i expected that it worked like before as there was no "hint" to that breaking change within the changelog. I digged a bit further it and found the following commit:
1507288c67c7d4d13cd825f0e5b0d530fe47bf34

This commit adds the `Spatie\Feed\Feedable` Type Hint to all the problematic lines (3 places). This is the only (real) change within the 3.0.0 release (See https://github.com/spatie/laravel-feed/compare/2.7.1...3.0.0).  This MR basically reverts the typehints so that it allow the FeedItems again. I guess the change was not intended because the `castToFeedItem` method still support FeedItem (and arrays): https://github.com/spatie/laravel-feed/blob/master/src/Feed.php#L68