### PR TITLE
RFC3339 compliant updated field

### DIFF
--- a/src/FeedItem.php
+++ b/src/FeedItem.php
@@ -62,7 +62,7 @@ class FeedItem
 
     public function updated(Carbon $updated): self
     {
-        $this->updated = $updated;
+        $this->updated = $updated->toRfc3339String();
 
         return $this;
     }


### PR DESCRIPTION
As mentioned in #114, the ```updated``` field should be RFC3339 compliant. This PR will address that.