### PR TITLE
Implement laravel-package-tools

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
         "php" : "^7.4|^8.0",
         "illuminate/support": "^7.0|^8.0",
         "illuminate/http": "^7.0|^8.0",
-        "illuminate/contracts": "^7.0|^8.0"
+        "illuminate/contracts": "^7.0|^8.0",
+        "spatie/laravel-package-tools": "^1.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.3",

--- a/src/FeedServiceProvider.php
+++ b/src/FeedServiceProvider.php
@@ -3,35 +3,32 @@
 namespace Spatie\Feed;
 
 use Illuminate\Support\Facades\View;
-use Illuminate\Support\ServiceProvider;
+use Spatie\LaravelPackageTools\PackageServiceProvider;
+use Spatie\LaravelPackageTools\Package;
 use Spatie\Feed\Helpers\Path;
 use Spatie\Feed\Http\FeedController;
 
-class FeedServiceProvider extends ServiceProvider
+class FeedServiceProvider extends PackageServiceProvider
 {
-    public function boot()
+    public function configurePackage(Package $package): void
     {
-        $this->publishes([
-            __DIR__.'/../config/feed.php' => config_path('feed.php'),
-        ], 'config');
+        $package
+            ->name('laravel-feed')
+            ->hasConfigFile()
+            ->hasViews();
+    }
 
-        $this->loadViewsFrom(__DIR__.'/../resources/views', 'feed');
-
-        $this->publishes([
-            __DIR__.'/../resources/views' => resource_path('views/vendor/feed'),
-        ], 'views');
-
+    public function packageBooted()
+    {
         $this->registerLinksComposer();
     }
 
-    public function register()
+    public function packageRegistered()
     {
-        $this->mergeConfigFrom(__DIR__.'/../config/feed.php', 'feed');
-
         $this->registerRouteMacro();
     }
 
-    protected function registerRouteMacro()
+    protected function registerRouteMacro(): void
     {
         $router = $this->app['router'];
 
@@ -44,7 +41,7 @@ class FeedServiceProvider extends ServiceProvider
         });
     }
 
-    public function registerLinksComposer()
+    public function registerLinksComposer(): void
     {
         View::composer('feed::links', function ($view) {
             $view->with('feeds', $this->feeds());


### PR DESCRIPTION
This PR implements `spatie/laravel-package-tools`, resulting in cleaner code for the service provider that is easier to maintain.