### PR TITLE
Package throws an exception when using with Statamic

### DIFF
--- a/src/FeedServiceProvider.php
+++ b/src/FeedServiceProvider.php
@@ -27,7 +27,10 @@ class FeedServiceProvider extends PackageServiceProvider
     public function packageRegistered()
     {
         $this->registerRouteMacro();
-
+    }
+    
+    public function packageBooted()
+    {
         if (! app()->runningUnitTests()) {
             ConfigurationValidator::validate();
         }


### PR DESCRIPTION
Statamic overrides the View instance, which isn't registered yet if you call the ConfigurationValidator in the packageRegistered function.