### PR TITLE
Fix config validation

### DIFF
--- a/src/Helpers/ConfigurationValidator.php
+++ b/src/Helpers/ConfigurationValidator.php
@@ -16,26 +16,21 @@ class ConfigurationValidator
                 throw InvalidConfiguration::unrecognizedFormat($name, $config['format']);
             }
 
-            if (! self::validateFeedItemsResolver($config['items'])) {
-                throw InvalidConfiguration::invalidItemsValue($name);
-            }
-
             if (! View::exists($config['view'] ?? 'feed::atom')) {
                 throw InvalidConfiguration::invalidView($name);
             }
         }
     }
 
-    protected static function validateFeedItemsResolver($resolver): bool
+    public static function validateResolver(string $feedName, $resolver): void
     {
-        if ($resolver === null) {
-            return true;
+        if (! self::feedItemsResolverIsValid($resolver)) {
+            throw InvalidConfiguration::invalidItemsValue($feedName);
         }
+    }
 
-        if ($resolver === '') {
-            return true;
-        }
-
+    protected static function feedItemsResolverIsValid($resolver): bool
+    {
         if (! is_string($resolver) && ! is_array($resolver)) {
             return false;
         }

--- a/src/Helpers/ResolveFeedItems.php
+++ b/src/Helpers/ResolveFeedItems.php
@@ -7,8 +7,10 @@ use Illuminate\Support\Collection;
 
 class ResolveFeedItems
 {
-    public static function resolve($resolver): Collection
+    public static function resolve(string $feedName, $resolver): Collection
     {
+        ConfigurationValidator::validateResolver($feedName, $resolver);
+
         $newResolver = $resolver;
 
         if (is_array($resolver) && ! str_contains($resolver[0], '@')) {

--- a/src/Http/FeedController.php
+++ b/src/Http/FeedController.php
@@ -18,7 +18,7 @@ class FeedController
 
         abort_unless($feed, 404);
 
-        $items = ResolveFeedItems::resolve($feed['items']);
+        $items = ResolveFeedItems::resolve($name, $feed['items']);
 
         return new Feed(
             $feed['title'],

--- a/tests/ConfigurationValidatorTest.php
+++ b/tests/ConfigurationValidatorTest.php
@@ -18,7 +18,6 @@ class ConfigurationValidatorTest extends TestCase
             try {
                 ConfigurationValidator::validate([
                     'feed1' => [
-                        'items' => 'Spatie\Feed\Test\DummyRepository@getAll',
                         'view' => 'feed::rss',
                         'format' => $format,
                     ],
@@ -38,7 +37,6 @@ class ConfigurationValidatorTest extends TestCase
 
         ConfigurationValidator::validate([
             'feed1' => [
-                'items' => 'Spatie\Feed\Test\DummyRepository@getAll',
                 'view' => 'feed::rss',
                 'format' => 'test',
             ],
@@ -50,20 +48,14 @@ class ConfigurationValidatorTest extends TestCase
     {
         $exceptionCounter = 0;
 
-        $invalidItems = [[], ['test']];
+        $invalidItems = [[], null, '', ['test']];
         $validItems = ['Model@getAll', ['App\\Model', 'getItems'], ['App\\Model', 'getItems', 'param1']];
 
         $items = array_merge($invalidItems, $validItems);
 
         foreach ($items as $itemsValue) {
             try {
-                ConfigurationValidator::validate([
-                    'feed1' => [
-                        'items' => $itemsValue,
-                        'view' => 'feed::rss',
-                        'format' => 'rss',
-                    ],
-                ]);
+                ConfigurationValidator::validateResolver('feed1', $itemsValue);
             } catch (InvalidConfiguration $e) {
                 $exceptionCounter++;
             }
@@ -82,7 +74,6 @@ class ConfigurationValidatorTest extends TestCase
             try {
                 ConfigurationValidator::validate([
                     'feed1' => [
-                        'items' => 'Spatie\Feed\Test\DummyRepository@getAll',
                         'view' => $view,
                         'format' => 'json',
                     ],

--- a/tests/ResolveFeedItemsTest.php
+++ b/tests/ResolveFeedItemsTest.php
@@ -9,7 +9,7 @@ class ResolveFeedItemsTest extends TestCase
     /** @test */
     public function it_resolves_a_resolver_class_and_method_string()
     {
-        $result = ResolveFeedItems::resolve('\Spatie\Feed\Test\DummyRepository@getAll');
+        $result = ResolveFeedItems::resolve('feed1', '\Spatie\Feed\Test\DummyRepository@getAll');
 
         $this->assertCount(5, $result);
     }
@@ -17,7 +17,7 @@ class ResolveFeedItemsTest extends TestCase
     /** @test */
     public function it_resolves_a_resolver_class_and_method_string_with_parameters()
     {
-        $result = ResolveFeedItems::resolve(['Spatie\Feed\Test\DummyRepository@getAllWithArguments', 'filter' => 'first']);
+        $result = ResolveFeedItems::resolve('feed1', ['Spatie\Feed\Test\DummyRepository@getAllWithArguments', 'filter' => 'first']);
 
         $this->assertCount(1, $result);
     }
@@ -25,7 +25,7 @@ class ResolveFeedItemsTest extends TestCase
     /** @test */
     public function it_resolves_a_resolver_class_and_method_tuple()
     {
-        $result = ResolveFeedItems::resolve([DummyRepository::class, 'getAll']);
+        $result = ResolveFeedItems::resolve('feed1', [DummyRepository::class, 'getAll']);
 
         $this->assertCount(5, $result);
     }
@@ -33,7 +33,7 @@ class ResolveFeedItemsTest extends TestCase
     /** @test */
     public function it_resolves_a_resolver_class_and_method_tuple_with_parameters()
     {
-        $result = ResolveFeedItems::resolve([DummyRepository::class, 'getAllWithArguments', 'filter' => 'first']);
+        $result = ResolveFeedItems::resolve('feed1', [DummyRepository::class, 'getAllWithArguments', 'filter' => 'first']);
 
         $this->assertCount(1, $result);
     }


### PR DESCRIPTION
This PR fixes an issue where the configuration validation throws an exception during installation of the package (resolves #158).  

The issue occurs because validation is performed after the package is booted.  The package is also booted as soon as it's installed by composer but before the user can update the config file with valid settings.  In turn, this causes an `"Invalid 'items' configuration value for feed 'NNN'"` exception to be thrown, and package installation fails.

Specifically, this PR:
- Moves the validation of the config `items` key to the `ResolveFeedItems::resolve()` method, allowing proper validation of the config while avoiding any issues during installation.  
- Updates unit tests accordingly.
- Has been checked to verify that installation of the package completes successfully.