### PR TITLE
Fix FeedItem update() use with CarbonImmutable date

### DIFF
--- a/src/FeedItem.php
+++ b/src/FeedItem.php
@@ -2,7 +2,7 @@
 
 namespace Spatie\Feed;
 
-use Carbon\Carbon;
+use Carbon\CarbonInterface;
 use Exception;
 use Spatie\Feed\Exceptions\InvalidFeedItem;
 
@@ -14,7 +14,7 @@ class FeedItem
 
     protected string $title;
 
-    protected Carbon $updated;
+    protected CarbonInterface $updated;
 
     protected string $summary;
 
@@ -66,7 +66,7 @@ class FeedItem
         return $this;
     }
 
-    public function updated(Carbon $updated): self
+    public function updated(CarbonInterface $updated): self
     {
         $this->updated = $updated;
 


### PR DESCRIPTION
Using the `FeedItem::update()` method after having set Carbon dates as immutable (https://dyrynda.com.au/blog/laravel-immutable-dates), currently causes this error.

![Capture d’écran 2021-10-13 à 15 28 32](https://user-images.githubusercontent.com/5328934/137143970-26a58edd-a025-4b3d-a4c8-9173eda6b845.png)

We can easily solve this by changing the `FeedItem` $updated attribute type by `CarbonInterface` instead of `Carbon` => it solves the error and make this package compatible with CarbonImmutable dates 👍 

I actually need this PR to be merged because we use your package on our projets. But I am also participating to this Hacktoberfest edition, so if you could tag this PR with `hacktoberfest-accepted` before merging, I would be grateful ! (I wouldn't feel offended if you don't).

Thanks and keep up the good work !