### PR TITLE
Set custom content type correctly

### DIFF
--- a/resources/views/links.blade.php
+++ b/resources/views/links.blade.php
@@ -1,3 +1,3 @@
 @foreach($feeds as $name => $feed)
-    <link rel="alternate" type="{{ \Spatie\Feed\Helpers\FeedContentType::forLink($feed['format'] ?? 'atom') }}" href="{{ route("feeds.{$name}") }}" title="{{ $feed['title'] }}">
+    <link rel="alternate" type="{{ \Spatie\Feed\Helpers\FeedContentType::forLink($name, $feed['format'] ?? 'atom') }}" href="{{ route("feeds.{$name}") }}" title="{{ $feed['title'] }}">
 @endforeach

--- a/src/Feed.php
+++ b/src/Feed.php
@@ -13,6 +13,7 @@ class Feed implements Responsable
     protected Collection $feedItems;
 
     public function __construct(
+        protected string $name,
         protected string $title,
         protected Collection $items,
         protected string $url = '',
@@ -30,6 +31,7 @@ class Feed implements Responsable
     public function toResponse($request): Response
     {
         $meta = [
+            'name' => $this->name,
             'id' => url($this->url),
             'link' => url($this->url),
             'title' => $this->title,
@@ -45,7 +47,7 @@ class Feed implements Responsable
         ]);
 
         return new Response($contents, 200, [
-            'Content-Type' => FeedContentType::forResponse($this->format) . ';charset=UTF-8',
+            'Content-Type' => FeedContentType::forResponse($this->name, $this->format) . ';charset=UTF-8',
         ]);
     }
 

--- a/src/Helpers/FeedContentType.php
+++ b/src/Helpers/FeedContentType.php
@@ -15,9 +15,9 @@ class FeedContentType
         'link' => 'application/atom+xml',
     ];
 
-    public static function forResponse(string $feedFormat): string
+    public static function forResponse(string $feedName, string $feedFormat): string
     {
-        $contentType = config('feed::contentType');
+        $contentType = config('feed.feeds.' . $feedName . '.contentType');
         $mappedType = self::$typeMap[$feedFormat]['response'] ?? self::$defaults['response'];
 
         return empty($contentType)
@@ -25,9 +25,9 @@ class FeedContentType
             : $contentType;
     }
 
-    public static function forLink(string $feedFormat): string
+    public static function forLink(string $feedName, string $feedFormat): string
     {
-        $type = config('feed::type');
+        $type = config('feed.feeds.' . $feedName . '.type');
         $mappedType = self::$typeMap[$feedFormat]['link'] ?? self::$defaults['link'];
 
         return empty($type)

--- a/src/Http/FeedController.php
+++ b/src/Http/FeedController.php
@@ -21,6 +21,7 @@ class FeedController
         $items = ResolveFeedItems::resolve($name, $feed['items']);
 
         return new Feed(
+            $name,
             $feed['title'],
             $items,
             request()->url(),

--- a/tests/FeedTest.php
+++ b/tests/FeedTest.php
@@ -93,6 +93,7 @@ class FeedTest extends TestCase
             'feed1' => 'application/xml',
             'feed1.rss' => 'application/xml',
             'feed1.json' => 'application/json',
+            'feed-with-custom-content-type' => 'application/atom+xml',
         ];
 
         collect($feeds)->each(function (string $contentType, $feedName) {

--- a/tests/FeedTest.php
+++ b/tests/FeedTest.php
@@ -60,7 +60,7 @@ class FeedTest extends TestCase
     {
         TestTime::freeze('Y-m-d H:i:s', '2020-01-01 00:00:00');
 
-        $feed = new Feed('title', collect([
+        $feed = new Feed('name', 'title', collect([
             [
                 'id' => 1,
                 'authorName' => 'John',

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -90,6 +90,16 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
                 'type' => 'application/feed+json',
                 'format' => 'json',
             ],
+            'feedcustomcontenttype' => [
+                'items' => 'Spatie\Feed\Test\DummyRepository@getAll',
+                'url' => '/feed-with-custom-content-type',
+                'title' => 'Feed with Custom Content-type',
+                'description' => 'This is a feed that uses a custom content-type',
+                'language' => 'en-US',
+                'image' => 'http://localhost/image.jpg',
+                'format' => 'atom',
+                'contentType' => 'application/atom+xml'
+            ],
         ];
 
         $app['config']->set('feed.feeds', $feed);

--- a/tests/__snapshots__/FeedTest__all_feed_items_have_expected_data__1.txt
+++ b/tests/__snapshots__/FeedTest__all_feed_items_have_expected_data__1.txt
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en-US">
-                        <id>http://localhost/feedBaseUrl/feed1</id>
+                        <name>feed1</name>
+                                <id>http://localhost/feedBaseUrl/feed1</id>
                                 <link href="http://localhost/feedBaseUrl/feed1" rel="self"></link>
                                 <title><![CDATA[Feed 1]]></title>
                                 <logo>http://localhost/image.jpg</logo>

--- a/tests/__snapshots__/FeedTest__all_feed_items_have_expected_data__2.txt
+++ b/tests/__snapshots__/FeedTest__all_feed_items_have_expected_data__2.txt
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en-US">
-                        <id>http://localhost/feedBaseUrl/feed2</id>
+                        <name>feed2</name>
+                                <id>http://localhost/feedBaseUrl/feed2</id>
                                 <link href="http://localhost/feedBaseUrl/feed2" rel="self"></link>
                                 <title><![CDATA[Feed 2]]></title>
                                 <logo>http://localhost/image.jpg</logo>

--- a/tests/__snapshots__/FeedTest__all_feed_items_have_expected_data__3.txt
+++ b/tests/__snapshots__/FeedTest__all_feed_items_have_expected_data__3.txt
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en-US">
-                        <id>http://localhost/feedBaseUrl/feed3</id>
+                        <name>feed3</name>
+                                <id>http://localhost/feedBaseUrl/feed3</id>
                                 <link href="http://localhost/feedBaseUrl/feed3" rel="self"></link>
                                 <title><![CDATA[Feed 3]]></title>
                                 <logo>http://localhost/image.jpg</logo>

--- a/tests/__snapshots__/FeedTest__it_can_accept_an_array__1.txt
+++ b/tests/__snapshots__/FeedTest__it_can_accept_an_array__1.txt
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom" xml:lang="">
-                        <id>http://localhost</id>
+                        <name>name</name>
+                                <id>http://localhost</id>
                                 <link href="http://localhost" rel="self"></link>
                                 <title><![CDATA[title]]></title>
                     

--- a/tests/__snapshots__/FeedTest__it_can_render_all_feed_links_via_a_view__1.txt
+++ b/tests/__snapshots__/FeedTest__it_can_render_all_feed_links_via_a_view__1.txt
@@ -4,3 +4,4 @@
     <link rel="alternate" type="application/atom+xml" href="http://localhost/feedBaseUrl/feed-with-custom-view" title="Feed with Custom View">
     <link rel="alternate" type="application/rss+xml" href="http://localhost/feedBaseUrl/feed1.rss" title="Feed 1 RSS">
     <link rel="alternate" type="application/feed+json" href="http://localhost/feedBaseUrl/feed1.json" title="Feed 1 JSON">
+    <link rel="alternate" type="application/atom+xml" href="http://localhost/feedBaseUrl/feed-with-custom-content-type" title="Feed with Custom Content-type">

--- a/tests/__snapshots__/FeedTest__it_can_render_all_feed_links_via_the_blade_component__1.txt
+++ b/tests/__snapshots__/FeedTest__it_can_render_all_feed_links_via_the_blade_component__1.txt
@@ -4,3 +4,4 @@
     <link rel="alternate" type="application/atom+xml" href="http://localhost/feedBaseUrl/feed-with-custom-view" title="Feed with Custom View">
     <link rel="alternate" type="application/rss+xml" href="http://localhost/feedBaseUrl/feed1.rss" title="Feed 1 RSS">
     <link rel="alternate" type="application/feed+json" href="http://localhost/feedBaseUrl/feed1.json" title="Feed 1 JSON">
+    <link rel="alternate" type="application/atom+xml" href="http://localhost/feedBaseUrl/feed-with-custom-content-type" title="Feed with Custom Content-type">


### PR DESCRIPTION
Use the feed name to get the custom content type set in the config.