### PR TITLE
fix: add optional desription to json feed

### DIFF
--- a/resources/views/json.blade.php
+++ b/resources/views/json.blade.php
@@ -1,6 +1,9 @@
 {
     "version": "https://jsonfeed.org/version/1.1",
     "title": "{{ $meta['title'] }}",
+@if(!empty($meta['description']))
+    "description": "{{ $meta['description'] }}",
+@endif
     "home_page_url": "{{ config('app.url') }}",
     "feed_url": "{{ url($meta['link']) }}",
     "language": "{{ $meta['language'] }}",

--- a/tests/__snapshots__/FeedTest__all_feed_items_have_expected_data__5.txt
+++ b/tests/__snapshots__/FeedTest__all_feed_items_have_expected_data__5.txt
@@ -1,6 +1,7 @@
 {
     "version": "https://jsonfeed.org/version/1.1",
     "title": "Feed 1 JSON",
+    "description": "This is feed 1 as JSON from the unit tests",
     "home_page_url": "http://localhost",
     "feed_url": "http://localhost/feedBaseUrl/feed1.json",
     "language": "en-US",


### PR DESCRIPTION
This adds the optional "description" key to the JSON, based on the meta description like the XML feeds.