### PR TITLE
fix: add top-level author to json feed

### DIFF
--- a/resources/views/json.blade.php
+++ b/resources/views/json.blade.php
@@ -7,6 +7,12 @@
 @if(!empty($meta['image']))
     "icon": "{{ $meta['image'] }}",
 @endif
+    "authors": [@foreach($items->unique('authorName') as $item){
+            "name": "{{ $item->authorName }}"
+        }@if(! $loop->last),@endif
+@endforeach
+
+    ],
     "items": [@foreach($items as $item){
             "id": "{{ url($item->id) }}",
             "title": "{{ $item->title }}",
@@ -29,7 +35,7 @@
             ],
 @endif
             "tags": [ {!! implode(',', array_map(fn($c) => '"'.$c.'"', $item->category)) !!} ]
-        }@if($item !== $items->last()),
+        }@if(! $loop->last),
 @endif
         @endforeach
 

--- a/tests/__snapshots__/FeedTest__all_feed_items_have_expected_data__5.txt
+++ b/tests/__snapshots__/FeedTest__all_feed_items_have_expected_data__5.txt
@@ -5,6 +5,10 @@
     "feed_url": "http://localhost/feedBaseUrl/feed1.json",
     "language": "en-US",
     "icon": "http://localhost/image.jpg",
+    "authors": [{
+            "name": "feedItemAuthor"
+        }
+    ],
     "items": [{
             "id": "http://localhost/1",
             "title": "feedItemTitle",


### PR DESCRIPTION
This adds the optional "authors" array to the top-level area of the JSON.