### PR TITLE
Don't escape entities inside CDATA

### DIFF
--- a/resources/views/atom.blade.php
+++ b/resources/views/atom.blade.php
@@ -7,7 +7,7 @@
         @if($key === 'link')
             <{{ $key }} href="{{ url($metaItem) }}" rel="self"></{{ $key }}>
         @elseif($key === 'title')
-            <{{ $key }}><![CDATA[{{ $metaItem }}]]></{{ $key }}>
+            <{{ $key }}>{!! \Spatie\Feed\Helpers\Cdata::out($metaItem) !!}</{{ $key }}>
         @elseif($key === 'description')
             <subtitle>{{ $metaItem }}</subtitle>
         @elseif($key === 'language')
@@ -23,18 +23,18 @@
     @endforeach
     @foreach($items as $item)
         <entry>
-            <title><![CDATA[{{ $item->title }}]]></title>
+            <title>{!! \Spatie\Feed\Helpers\Cdata::out($item->title) !!}</title>
             <link rel="alternate" href="{{ url($item->link) }}" />
             <id>{{ url($item->id) }}</id>
             <author>
-                <name><![CDATA[{{ $item->authorName }}]]></name>
+                <name>{!! \Spatie\Feed\Helpers\Cdata::out($item->authorName) !!}</name>
 @if(!empty($item->authorEmail))
-                <email><![CDATA[{{ $item->authorEmail }}]]></email>
+                <email>{!! \Spatie\Feed\Helpers\Cdata::out($item->authorEmail) !!}</email>
 
 @endif
             </author>
             <summary type="html">
-                <![CDATA[{!! $item->summary !!}]]>
+                {!! \Spatie\Feed\Helpers\Cdata::out($item->summary) !!}
             </summary>
             @if($item->__isset('enclosure'))
             <link href="{{ url($item->enclosure) }}" length="{{ $item->enclosureLength }}" type="{{ $item->enclosureType }}" />

--- a/resources/views/json.blade.php
+++ b/resources/views/json.blade.php
@@ -18,13 +18,13 @@
     ],
     "items": [@foreach($items as $item){
             "id": "{{ url($item->id) }}",
-            "title": "{{ $item->title }}",
+            "title": {!! json_encode($item->title) !!},
             "url": "{{ url($item->link) }}",
             "content_html": {!! json_encode($item->summary) !!},
             "summary": {!! json_encode($item->summary) !!},
             "date_published": "{{ $item->timestamp() }}",
             "date_modified": "{{ $item->timestamp() }}",
-            "authors": [{ "name": "{{ $item->authorName }}" }],
+            "authors": [{ "name": {!! json_encode($item->authorName) !!} }],
 @if($item->__isset('image'))
             "image": "{{ url($item->image) }}",
 @endif

--- a/resources/views/rss.blade.php
+++ b/resources/views/rss.blade.php
@@ -5,25 +5,25 @@
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
     <channel>
         <atom:link href="{{ url($meta['link']) }}" rel="self" type="application/rss+xml" />
-        <title><![CDATA[{{ $meta['title'] }}]]></title>
-        <link><![CDATA[{{ url($meta['link']) }}]]></link>
+        <title>{!! \Spatie\Feed\Helpers\Cdata::out($meta['title'] ) !!}</title>
+        <link>{!! \Spatie\Feed\Helpers\Cdata::out(url($meta['link']) ) !!}</link>
 @if(!empty($meta['image']))
         <image>
             <url>{{ $meta['image'] }}</url>
-            <title><![CDATA[{{ $meta['title'] }}]]></title>
-            <link><![CDATA[{{ url($meta['link']) }}]]></link>
+            <title>{!! \Spatie\Feed\Helpers\Cdata::out($meta['title'] ) !!}</title>
+            <link>{!! \Spatie\Feed\Helpers\Cdata::out(url($meta['link']) ) !!}</link>
         </image>
 @endif
-        <description><![CDATA[{{ $meta['description'] }}]]></description>
+        <description>{!! \Spatie\Feed\Helpers\Cdata::out($meta['description'] ) !!}</description>
         <language>{{ $meta['language'] }}</language>
         <pubDate>{{ $meta['updated'] }}</pubDate>
 
         @foreach($items as $item)
             <item>
-                <title><![CDATA[{{ $item->title }}]]></title>
+                <title>{!! \Spatie\Feed\Helpers\Cdata::out($item->title) !!}</title>
                 <link>{{ url($item->link) }}</link>
-                <description><![CDATA[{!! $item->summary !!}]]></description>
-                <author><![CDATA[{{ $item->authorName }}@if(!empty($item->authorEmail)) <{{ $item->authorEmail }}>@endif]]></author>
+                <description>{!! \Spatie\Feed\Helpers\Cdata::out($item->summary) !!}</description>
+                <author>{!! \Spatie\Feed\Helpers\Cdata::out($item->authorName.(empty($item->authorEmail)?'':' <'.$item->authorEmail.'>')) !!}</author>
                 <guid>{{ url($item->id) }}</guid>
                 <pubDate>{{ $item->timestamp() }}</pubDate>
                 @foreach($item->category as $category)

--- a/src/Helpers/Cdata.php
+++ b/src/Helpers/Cdata.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Spatie\Feed\Helpers;
+
+class Cdata
+{
+    public static function out( string $data ): string
+    {
+        // See https://www.w3.org/TR/REC-xml/#dt-cdsection
+        $replace = [
+            '<!CDATA[' => '', // CDATA cannot be nested.
+            ']]>' => ']]&gt;', // CDEnd needs to be escaped.
+        ];
+        return '<![CDATA[' . str_replace(array_keys($replace), array_values($replace), $data ) . ']]>';
+    }
+
+}

--- a/tests/DummyItem.php
+++ b/tests/DummyItem.php
@@ -16,7 +16,7 @@ class DummyItem implements Feedable
     {
         return new FeedItem([
             'id' => $this->id,
-            'title' => 'feedItemTitle',
+            'title' => 'feed<>]]>Item"Title"',
             'summary' => 'feedItemSummary',
             'enclosure' => 'http://localhost/image1.jpg',
             'enclosureLength' => 31300,

--- a/tests/__snapshots__/FeedTest__all_feed_items_have_expected_data__1.php
+++ b/tests/__snapshots__/FeedTest__all_feed_items_have_expected_data__1.php
@@ -9,7 +9,7 @@ return '<?xml version="1.0" encoding="UTF-8"?>
                                 <language>en-US</language>
                                 <updated>Fri, 01 Jan 2016 00:00:00 +0100</updated>
                         <entry>
-            <title><![CDATA[feedItemTitle]]></title>
+            <title><![CDATA[feed<>]]&gt;Item"Title"]]></title>
             <link rel="alternate" href="https://localhost/news/testItem1" />
             <id>http://localhost/1</id>
             <author>
@@ -25,7 +25,7 @@ return '<?xml version="1.0" encoding="UTF-8"?>
                         <updated>Fri, 01 Jan 2016 00:00:00 +0100</updated>
         </entry>
             <entry>
-            <title><![CDATA[feedItemTitle]]></title>
+            <title><![CDATA[feed<>]]&gt;Item"Title"]]></title>
             <link rel="alternate" href="https://localhost/news/testItem1" />
             <id>http://localhost/1</id>
             <author>
@@ -41,7 +41,7 @@ return '<?xml version="1.0" encoding="UTF-8"?>
                         <updated>Fri, 01 Jan 2016 00:00:00 +0100</updated>
         </entry>
             <entry>
-            <title><![CDATA[feedItemTitle]]></title>
+            <title><![CDATA[feed<>]]&gt;Item"Title"]]></title>
             <link rel="alternate" href="https://localhost/news/testItem1" />
             <id>http://localhost/1</id>
             <author>
@@ -57,7 +57,7 @@ return '<?xml version="1.0" encoding="UTF-8"?>
                         <updated>Fri, 01 Jan 2016 00:00:00 +0100</updated>
         </entry>
             <entry>
-            <title><![CDATA[feedItemTitle]]></title>
+            <title><![CDATA[feed<>]]&gt;Item"Title"]]></title>
             <link rel="alternate" href="https://localhost/news/testItem1" />
             <id>http://localhost/1</id>
             <author>
@@ -73,7 +73,7 @@ return '<?xml version="1.0" encoding="UTF-8"?>
                         <updated>Fri, 01 Jan 2016 00:00:00 +0100</updated>
         </entry>
             <entry>
-            <title><![CDATA[feedItemTitle]]></title>
+            <title><![CDATA[feed<>]]&gt;Item"Title"]]></title>
             <link rel="alternate" href="https://localhost/news/testItem1" />
             <id>http://localhost/1</id>
             <author>

--- a/tests/__snapshots__/FeedTest__all_feed_items_have_expected_data__1.txt
+++ b/tests/__snapshots__/FeedTest__all_feed_items_have_expected_data__1.txt
@@ -7,7 +7,7 @@
                                 <subtitle>This is feed 1 from the unit tests</subtitle>
                                                     <updated>2015-12-31T22:59:00+00:00</updated>
                         <entry>
-            <title><![CDATA[feedItemTitle]]></title>
+            <title><![CDATA[feed<>]]&gt;Item"Title"]]></title>
             <link rel="alternate" href="https://localhost/news/testItem1" />
             <id>http://localhost/1</id>
             <author>
@@ -23,7 +23,7 @@
                         <updated>2015-12-31T22:59:00+00:00</updated>
         </entry>
             <entry>
-            <title><![CDATA[feedItemTitle]]></title>
+            <title><![CDATA[feed<>]]&gt;Item"Title"]]></title>
             <link rel="alternate" href="https://localhost/news/testItem2" />
             <id>http://localhost/2</id>
             <author>
@@ -39,7 +39,7 @@
                         <updated>2015-12-31T22:58:00+00:00</updated>
         </entry>
             <entry>
-            <title><![CDATA[feedItemTitle]]></title>
+            <title><![CDATA[feed<>]]&gt;Item"Title"]]></title>
             <link rel="alternate" href="https://localhost/news/testItem3" />
             <id>http://localhost/3</id>
             <author>
@@ -55,7 +55,7 @@
                         <updated>2015-12-31T22:57:00+00:00</updated>
         </entry>
             <entry>
-            <title><![CDATA[feedItemTitle]]></title>
+            <title><![CDATA[feed<>]]&gt;Item"Title"]]></title>
             <link rel="alternate" href="https://localhost/news/testItem4" />
             <id>http://localhost/4</id>
             <author>
@@ -71,7 +71,7 @@
                         <updated>2015-12-31T22:56:00+00:00</updated>
         </entry>
             <entry>
-            <title><![CDATA[feedItemTitle]]></title>
+            <title><![CDATA[feed<>]]&gt;Item"Title"]]></title>
             <link rel="alternate" href="https://localhost/news/testItem5" />
             <id>http://localhost/5</id>
             <author>

--- a/tests/__snapshots__/FeedTest__all_feed_items_have_expected_data__2.php
+++ b/tests/__snapshots__/FeedTest__all_feed_items_have_expected_data__2.php
@@ -9,7 +9,7 @@ return '<?xml version="1.0" encoding="UTF-8"?>
                                 <language>en-US</language>
                                 <updated>Fri, 01 Jan 2016 00:00:00 +0100</updated>
                         <entry>
-            <title><![CDATA[feedItemTitle]]></title>
+            <title><![CDATA[feed<>]]&gt;Item"Title"]]></title>
             <link rel="alternate" href="https://localhost/news/testItem1" />
             <id>http://localhost/1</id>
             <author>
@@ -25,7 +25,7 @@ return '<?xml version="1.0" encoding="UTF-8"?>
                         <updated>Fri, 01 Jan 2016 00:00:00 +0100</updated>
         </entry>
             <entry>
-            <title><![CDATA[feedItemTitle]]></title>
+            <title><![CDATA[feed<>]]&gt;Item"Title"]]></title>
             <link rel="alternate" href="https://localhost/news/testItem1" />
             <id>http://localhost/1</id>
             <author>
@@ -41,7 +41,7 @@ return '<?xml version="1.0" encoding="UTF-8"?>
                         <updated>Fri, 01 Jan 2016 00:00:00 +0100</updated>
         </entry>
             <entry>
-            <title><![CDATA[feedItemTitle]]></title>
+            <title><![CDATA[feed<>]]&gt;Item"Title"]]></title>
             <link rel="alternate" href="https://localhost/news/testItem1" />
             <id>http://localhost/1</id>
             <author>
@@ -57,7 +57,7 @@ return '<?xml version="1.0" encoding="UTF-8"?>
                         <updated>Fri, 01 Jan 2016 00:00:00 +0100</updated>
         </entry>
             <entry>
-            <title><![CDATA[feedItemTitle]]></title>
+            <title><![CDATA[feed<>]]&gt;Item"Title"]]></title>
             <link rel="alternate" href="https://localhost/news/testItem1" />
             <id>http://localhost/1</id>
             <author>
@@ -73,7 +73,7 @@ return '<?xml version="1.0" encoding="UTF-8"?>
                         <updated>Fri, 01 Jan 2016 00:00:00 +0100</updated>
         </entry>
             <entry>
-            <title><![CDATA[feedItemTitle]]></title>
+            <title><![CDATA[feed<>]]&gt;Item"Title"]]></title>
             <link rel="alternate" href="https://localhost/news/testItem1" />
             <id>http://localhost/1</id>
             <author>

--- a/tests/__snapshots__/FeedTest__all_feed_items_have_expected_data__2.txt
+++ b/tests/__snapshots__/FeedTest__all_feed_items_have_expected_data__2.txt
@@ -7,7 +7,7 @@
                                 <subtitle>This is feed 2 from the unit tests</subtitle>
                                                     <updated>2015-12-31T22:59:00+00:00</updated>
                         <entry>
-            <title><![CDATA[feedItemTitle]]></title>
+            <title><![CDATA[feed<>]]&gt;Item"Title"]]></title>
             <link rel="alternate" href="https://localhost/news/testItem1" />
             <id>http://localhost/1</id>
             <author>
@@ -23,7 +23,7 @@
                         <updated>2015-12-31T22:59:00+00:00</updated>
         </entry>
             <entry>
-            <title><![CDATA[feedItemTitle]]></title>
+            <title><![CDATA[feed<>]]&gt;Item"Title"]]></title>
             <link rel="alternate" href="https://localhost/news/testItem2" />
             <id>http://localhost/2</id>
             <author>
@@ -39,7 +39,7 @@
                         <updated>2015-12-31T22:58:00+00:00</updated>
         </entry>
             <entry>
-            <title><![CDATA[feedItemTitle]]></title>
+            <title><![CDATA[feed<>]]&gt;Item"Title"]]></title>
             <link rel="alternate" href="https://localhost/news/testItem3" />
             <id>http://localhost/3</id>
             <author>
@@ -55,7 +55,7 @@
                         <updated>2015-12-31T22:57:00+00:00</updated>
         </entry>
             <entry>
-            <title><![CDATA[feedItemTitle]]></title>
+            <title><![CDATA[feed<>]]&gt;Item"Title"]]></title>
             <link rel="alternate" href="https://localhost/news/testItem4" />
             <id>http://localhost/4</id>
             <author>
@@ -71,7 +71,7 @@
                         <updated>2015-12-31T22:56:00+00:00</updated>
         </entry>
             <entry>
-            <title><![CDATA[feedItemTitle]]></title>
+            <title><![CDATA[feed<>]]&gt;Item"Title"]]></title>
             <link rel="alternate" href="https://localhost/news/testItem5" />
             <id>http://localhost/5</id>
             <author>

--- a/tests/__snapshots__/FeedTest__all_feed_items_have_expected_data__3.php
+++ b/tests/__snapshots__/FeedTest__all_feed_items_have_expected_data__3.php
@@ -9,7 +9,7 @@ return '<?xml version="1.0" encoding="UTF-8"?>
                                 <language>en-US</language>
                                 <updated>Fri, 01 Jan 2016 00:00:00 +0100</updated>
                         <entry>
-            <title><![CDATA[feedItemTitle]]></title>
+            <title><![CDATA[feed<>]]&gt;Item"Title"]]></title>
             <link rel="alternate" href="https://localhost/news/testItem1" />
             <id>http://localhost/1</id>
             <author>
@@ -25,7 +25,7 @@ return '<?xml version="1.0" encoding="UTF-8"?>
                         <updated>Fri, 01 Jan 2016 00:00:00 +0100</updated>
         </entry>
             <entry>
-            <title><![CDATA[feedItemTitle]]></title>
+            <title><![CDATA[feed<>]]&gt;Item"Title"]]></title>
             <link rel="alternate" href="https://localhost/news/testItem1" />
             <id>http://localhost/1</id>
             <author>
@@ -41,7 +41,7 @@ return '<?xml version="1.0" encoding="UTF-8"?>
                         <updated>Fri, 01 Jan 2016 00:00:00 +0100</updated>
         </entry>
             <entry>
-            <title><![CDATA[feedItemTitle]]></title>
+            <title><![CDATA[feed<>]]&gt;Item"Title"]]></title>
             <link rel="alternate" href="https://localhost/news/testItem1" />
             <id>http://localhost/1</id>
             <author>
@@ -57,7 +57,7 @@ return '<?xml version="1.0" encoding="UTF-8"?>
                         <updated>Fri, 01 Jan 2016 00:00:00 +0100</updated>
         </entry>
             <entry>
-            <title><![CDATA[feedItemTitle]]></title>
+            <title><![CDATA[feed<>]]&gt;Item"Title"]]></title>
             <link rel="alternate" href="https://localhost/news/testItem1" />
             <id>http://localhost/1</id>
             <author>
@@ -73,7 +73,7 @@ return '<?xml version="1.0" encoding="UTF-8"?>
                         <updated>Fri, 01 Jan 2016 00:00:00 +0100</updated>
         </entry>
             <entry>
-            <title><![CDATA[feedItemTitle]]></title>
+            <title><![CDATA[feed<>]]&gt;Item"Title"]]></title>
             <link rel="alternate" href="https://localhost/news/testItem1" />
             <id>http://localhost/1</id>
             <author>

--- a/tests/__snapshots__/FeedTest__all_feed_items_have_expected_data__3.txt
+++ b/tests/__snapshots__/FeedTest__all_feed_items_have_expected_data__3.txt
@@ -7,7 +7,7 @@
                                 <subtitle>This is feed 3 from the unit tests</subtitle>
                                                     <updated>2015-12-31T22:59:00+00:00</updated>
                         <entry>
-            <title><![CDATA[feedItemTitle]]></title>
+            <title><![CDATA[feed<>]]&gt;Item"Title"]]></title>
             <link rel="alternate" href="https://localhost/news/testItem1" />
             <id>http://localhost/1</id>
             <author>
@@ -23,7 +23,7 @@
                         <updated>2015-12-31T22:59:00+00:00</updated>
         </entry>
             <entry>
-            <title><![CDATA[feedItemTitle]]></title>
+            <title><![CDATA[feed<>]]&gt;Item"Title"]]></title>
             <link rel="alternate" href="https://localhost/news/testItem2" />
             <id>http://localhost/2</id>
             <author>
@@ -39,7 +39,7 @@
                         <updated>2015-12-31T22:58:00+00:00</updated>
         </entry>
             <entry>
-            <title><![CDATA[feedItemTitle]]></title>
+            <title><![CDATA[feed<>]]&gt;Item"Title"]]></title>
             <link rel="alternate" href="https://localhost/news/testItem3" />
             <id>http://localhost/3</id>
             <author>
@@ -55,7 +55,7 @@
                         <updated>2015-12-31T22:57:00+00:00</updated>
         </entry>
             <entry>
-            <title><![CDATA[feedItemTitle]]></title>
+            <title><![CDATA[feed<>]]&gt;Item"Title"]]></title>
             <link rel="alternate" href="https://localhost/news/testItem4" />
             <id>http://localhost/4</id>
             <author>
@@ -71,7 +71,7 @@
                         <updated>2015-12-31T22:56:00+00:00</updated>
         </entry>
             <entry>
-            <title><![CDATA[feedItemTitle]]></title>
+            <title><![CDATA[feed<>]]&gt;Item"Title"]]></title>
             <link rel="alternate" href="https://localhost/news/testItem5" />
             <id>http://localhost/5</id>
             <author>

--- a/tests/__snapshots__/FeedTest__all_feed_items_have_expected_data__4.php
+++ b/tests/__snapshots__/FeedTest__all_feed_items_have_expected_data__4.php
@@ -10,7 +10,7 @@ return '<?xml version="1.0" encoding="UTF-8"?>
         <pubDate>Fri, 01 Jan 2016 00:00:00 +0100</pubDate>
 
                     <item>
-                <title><![CDATA[feedItemTitle]]></title>
+                <title><![CDATA[feed<>]]&gt;Item"Title"]]></title>
                 <link>https://localhost/news/testItem1</link>
                 <description><![CDATA[feedItemSummary]]></description>
                 <author><![CDATA[feedItemAuthor]]></author>
@@ -19,7 +19,7 @@ return '<?xml version="1.0" encoding="UTF-8"?>
                                     <category>feedItemCategory</category>
                             </item>
                     <item>
-                <title><![CDATA[feedItemTitle]]></title>
+                <title><![CDATA[feed<>]]&gt;Item"Title"]]></title>
                 <link>https://localhost/news/testItem1</link>
                 <description><![CDATA[feedItemSummary]]></description>
                 <author><![CDATA[feedItemAuthor]]></author>
@@ -28,7 +28,7 @@ return '<?xml version="1.0" encoding="UTF-8"?>
                                     <category>feedItemCategory</category>
                             </item>
                     <item>
-                <title><![CDATA[feedItemTitle]]></title>
+                <title><![CDATA[feed<>]]&gt;Item"Title"]]></title>
                 <link>https://localhost/news/testItem1</link>
                 <description><![CDATA[feedItemSummary]]></description>
                 <author><![CDATA[feedItemAuthor]]></author>
@@ -37,7 +37,7 @@ return '<?xml version="1.0" encoding="UTF-8"?>
                                     <category>feedItemCategory</category>
                             </item>
                     <item>
-                <title><![CDATA[feedItemTitle]]></title>
+                <title><![CDATA[feed<>]]&gt;Item"Title"]]></title>
                 <link>https://localhost/news/testItem1</link>
                 <description><![CDATA[feedItemSummary]]></description>
                 <author><![CDATA[feedItemAuthor]]></author>
@@ -46,7 +46,7 @@ return '<?xml version="1.0" encoding="UTF-8"?>
                                     <category>feedItemCategory</category>
                             </item>
                     <item>
-                <title><![CDATA[feedItemTitle]]></title>
+                <title><![CDATA[feed<>]]&gt;Item"Title"]]></title>
                 <link>https://localhost/news/testItem1</link>
                 <description><![CDATA[feedItemSummary]]></description>
                 <author><![CDATA[feedItemAuthor]]></author>

--- a/tests/__snapshots__/FeedTest__all_feed_items_have_expected_data__4.txt
+++ b/tests/__snapshots__/FeedTest__all_feed_items_have_expected_data__4.txt
@@ -14,7 +14,7 @@
         <pubDate>Thu, 31 Dec 2015 22:59:00 +0000</pubDate>
 
                     <item>
-                <title><![CDATA[feedItemTitle]]></title>
+                <title><![CDATA[feed<>]]&gt;Item"Title"]]></title>
                 <link>https://localhost/news/testItem1</link>
                 <description><![CDATA[feedItemSummary]]></description>
                 <author><![CDATA[feedItemAuthor <feedItemAuthor@test.test>]]></author>
@@ -23,7 +23,7 @@
                                     <category>feedItemCategory</category>
                             </item>
                     <item>
-                <title><![CDATA[feedItemTitle]]></title>
+                <title><![CDATA[feed<>]]&gt;Item"Title"]]></title>
                 <link>https://localhost/news/testItem2</link>
                 <description><![CDATA[feedItemSummary]]></description>
                 <author><![CDATA[feedItemAuthor <feedItemAuthor@test.test>]]></author>
@@ -32,7 +32,7 @@
                                     <category>feedItemCategory</category>
                             </item>
                     <item>
-                <title><![CDATA[feedItemTitle]]></title>
+                <title><![CDATA[feed<>]]&gt;Item"Title"]]></title>
                 <link>https://localhost/news/testItem3</link>
                 <description><![CDATA[feedItemSummary]]></description>
                 <author><![CDATA[feedItemAuthor <feedItemAuthor@test.test>]]></author>
@@ -41,7 +41,7 @@
                                     <category>feedItemCategory</category>
                             </item>
                     <item>
-                <title><![CDATA[feedItemTitle]]></title>
+                <title><![CDATA[feed<>]]&gt;Item"Title"]]></title>
                 <link>https://localhost/news/testItem4</link>
                 <description><![CDATA[feedItemSummary]]></description>
                 <author><![CDATA[feedItemAuthor <feedItemAuthor@test.test>]]></author>
@@ -50,7 +50,7 @@
                                     <category>feedItemCategory</category>
                             </item>
                     <item>
-                <title><![CDATA[feedItemTitle]]></title>
+                <title><![CDATA[feed<>]]&gt;Item"Title"]]></title>
                 <link>https://localhost/news/testItem5</link>
                 <description><![CDATA[feedItemSummary]]></description>
                 <author><![CDATA[feedItemAuthor <feedItemAuthor@test.test>]]></author>

--- a/tests/__snapshots__/FeedTest__all_feed_items_have_expected_data__5.txt
+++ b/tests/__snapshots__/FeedTest__all_feed_items_have_expected_data__5.txt
@@ -12,7 +12,7 @@
     ],
     "items": [{
             "id": "http://localhost/1",
-            "title": "feedItemTitle",
+            "title": "feed<>]]>Item\"Title\"",
             "url": "https://localhost/news/testItem1",
             "content_html": "feedItemSummary",
             "summary": "feedItemSummary",
@@ -30,7 +30,7 @@
         },
         {
             "id": "http://localhost/2",
-            "title": "feedItemTitle",
+            "title": "feed<>]]>Item\"Title\"",
             "url": "https://localhost/news/testItem2",
             "content_html": "feedItemSummary",
             "summary": "feedItemSummary",
@@ -48,7 +48,7 @@
         },
         {
             "id": "http://localhost/3",
-            "title": "feedItemTitle",
+            "title": "feed<>]]>Item\"Title\"",
             "url": "https://localhost/news/testItem3",
             "content_html": "feedItemSummary",
             "summary": "feedItemSummary",
@@ -66,7 +66,7 @@
         },
         {
             "id": "http://localhost/4",
-            "title": "feedItemTitle",
+            "title": "feed<>]]>Item\"Title\"",
             "url": "https://localhost/news/testItem4",
             "content_html": "feedItemSummary",
             "summary": "feedItemSummary",
@@ -84,7 +84,7 @@
         },
         {
             "id": "http://localhost/5",
-            "title": "feedItemTitle",
+            "title": "feed<>]]>Item\"Title\"",
             "url": "https://localhost/news/testItem5",
             "content_html": "feedItemSummary",
             "summary": "feedItemSummary",


### PR DESCRIPTION
Laravel feeds of posts that contain quotes in titles when parsed by standard-compliant XML parsers, contain `&quot;` instead of just a `"`. The reason is that a CDATA section is being used in combination with [Blade's `htmlspecialchars` handling](https://laravel.com/docs/9.x/blade#displaying-data).

https://www.w3.org/TR/REC-xml/#dt-cdsection

> Within a CDATA section, only the [CDEnd](https://www.w3.org/TR/REC-xml/#NT-CDEnd) string is recognized as markup, so that left angle brackets and ampersands may occur in their literal form; they need not (and cannot) be escaped using " &lt; " and " &amp; ". CDATA sections cannot nest.

One possible solution would be to just remove the CDATA sections and let `htmlspecialchars` do its thing or to create a special output function for CDATA content. I chose the latter approach.

For unit tests, I have just added some "dangerous" markup to the `"feedItemTitle"` of the `DummyItem`s but I am not sure this is the best approach. Please advise.