### PR TITLE
Update FeedItem to support integer ids for strong typesafety

### DIFF
--- a/src/FeedItem.php
+++ b/src/FeedItem.php
@@ -52,9 +52,9 @@ class FeedItem
         return new static($data);
     }
 
-    public function id(string $id): self
+    public function id(string | int $id): self
     {
-        $this->id = $id;
+        $this->id = (string) $id;
 
         return $this;
     }


### PR DESCRIPTION
IDs often are integer type, but can be string type. My commit updates the type definition to support int and casts it to string.