### PR TITLE
remove unnecessary `language` key

### DIFF
--- a/resources/views/atom.blade.php
+++ b/resources/views/atom.blade.php
@@ -12,7 +12,6 @@
             <{{ $key }}>{!! \Spatie\Feed\Helpers\Cdata::out($metaItem) !!}</{{ $key }}>
         @elseif($key === 'description')
             <subtitle>{{ $metaItem }}</subtitle>
-        @elseif($key === 'language')
         @elseif($key === 'image')
 @if(!empty($metaItem))
             <logo>{!! $metaItem !!}</logo>


### PR DESCRIPTION
There is no need for the meta item `language` when looping through the meta items; the `elseif` statement checks it in the loop, but does nothing with it.